### PR TITLE
Remove unused imports

### DIFF
--- a/test/async_memoizer_test.dart
+++ b/test/async_memoizer_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:async/async.dart';
 import 'package:test/test.dart';
 

--- a/test/restartable_timer_test.dart
+++ b/test/restartable_timer_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:async/async.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
This fixes `Unused import [UNUSED_IMPORT]` analyzer warnings.