### PR TITLE
Change signature of methods overriding Future.then

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.3
+
+* Fix strong-mode warning against the signature of Future.then
+
 ## 1.11.1
 
 * Fix new strong-mode warnings introduced in Dart 1.17.0.

--- a/lib/src/delegate/future.dart
+++ b/lib/src/delegate/future.dart
@@ -25,13 +25,13 @@ class DelegatingFuture<T> implements Future<T> {
   Stream<T> asStream() => _future.asStream();
 
   Future<T> catchError(Function onError, {bool test(Object error)}) =>
-      _future.catchError(onError, test: test);
+    _future.catchError(onError, test: test);
 
   Future/*<S>*/ then/*<S>*/(dynamic onValue(T value), {Function onError}) =>
-      _future.then(onValue, onError: onError);
+    _future.then(onValue, onError: onError);
 
   Future<T> whenComplete(action()) => _future.whenComplete(action);
 
   Future<T> timeout(Duration timeLimit, {onTimeout()}) =>
-      _future.timeout(timeLimit, onTimeout: onTimeout);
+    _future.timeout(timeLimit, onTimeout: onTimeout);
 }

--- a/lib/src/delegate/future.dart
+++ b/lib/src/delegate/future.dart
@@ -25,13 +25,13 @@ class DelegatingFuture<T> implements Future<T> {
   Stream<T> asStream() => _future.asStream();
 
   Future<T> catchError(Function onError, {bool test(Object error)}) =>
-    _future.catchError(onError, test: test);
+      _future.catchError(onError, test: test);
 
-  Future/*<S>*/ then/*<S>*/(/*=S*/ onValue(T value), {Function onError}) =>
-    _future.then(onValue, onError: onError);
+  Future/*<S>*/ then/*<S>*/(dynamic onValue(T value), {Function onError}) =>
+      _future.then(onValue, onError: onError);
 
   Future<T> whenComplete(action()) => _future.whenComplete(action);
 
   Future<T> timeout(Duration timeLimit, {onTimeout()}) =>
-    _future.timeout(timeLimit, onTimeout: onTimeout);
+      _future.timeout(timeLimit, onTimeout: onTimeout);
 }

--- a/lib/src/typed/future.dart
+++ b/lib/src/typed/future.dart
@@ -14,7 +14,7 @@ class TypeSafeFuture<T> implements Future<T> {
   Future<T> catchError(Function onError, {bool test(Object error)}) async =>
       new TypeSafeFuture<T>(_future.catchError(onError, test: test));
 
-  Future/*<S>*/ then/*<S>*/(/*=S*/ onValue(T value), {Function onError}) =>
+  Future/*<S>*/ then/*<S>*/(dynamic onValue(T value), {Function onError}) =>
       _future.then((value) => onValue(value as T), onError: onError);
 
   Future<T> whenComplete(action()) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,4 @@ dev_dependencies:
   stack_trace: "^1.0.0"
   test: "^0.12.0"
 environment:
-  sdk: ">=1.12.0 <2.0.0"
+  sdk: ">=1.19.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 1.11.2
+version: 1.11.3
 author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async


### PR DESCRIPTION
The signature is:
`Future<T>.then (<S>((T) → dynamic, {onError: Function}) → Future<S>)`

Use `dynamic` rather than leave off the type to future proof against
`--no-implicit-dynamic`

cleanup: dartfmt