### PR TITLE
Add StreamQueue.startTransactions().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.12.0
+
+* Add `StreamQueue.startTransaction()` and `StreamQueue.startTransactions()`.
+  These allow users to conditionally consume events based on their values.
+
 ## 1.11.3
 
 * Fix strong-mode warning against the signature of Future.then

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 1.11.3
+version: 1.12.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async


### PR DESCRIPTION
This is important for advanced pull-based stream manipulation. It allows
users to express logic of the form "consume the next events if they
match this predicate".