### PR TITLE
Add StreamQueue.eventsDispatched.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Add `StreamQueue.cancelable()`, which allows users to easily make a
   `CancelableOperation` that can be canceled without affecting the queue.
 
+* Add `StreamQueue.eventsDispatched` which counts the number of events that have
+  been dispatched by a given queue.
+
 * Add a `subscriptionTransformer()` function to create `StreamTransformer`s that
   modify the behavior of subscriptions to a stream.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 1.12.0-dev
+version: 1.12.0
 author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async


### PR DESCRIPTION
This is useful for advanced transaction operations, such as "one of the
following consumers accepts the queue". We want to reliably accept the
same consumer every time, and the best way to do that is to accept the
one that consumed the most events.