### PR TITLE
Add stream_transformers library and buffer utility

### DIFF
--- a/lib/src/stream_transformers/buffer.dart
+++ b/lib/src/stream_transformers/buffer.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+/// Creates a [StreamTransformer] which collects values and emits when it sees a
+/// value on [trigger].
+///
+/// If there are no pending values when [trigger] emits, the next value on the
+/// source Stream will immediately flow through. Otherwise, the pending values
+/// are released when [trigger] emits.
+StreamTransformer<T, List<T>> buffer<T>(Stream trigger) =>
+    new _Buffer(trigger, _collectToList);
+
+List<T> _collectToList<T>(T element, List<T> soFar) {
+  soFar ??= <T>[];
+  soFar.add(element);
+  return soFar;
+}
+
+/// A strategy for aggregating values.
+typedef R _Collect<T, R>(T element, R soFar);
+
+/// A StreamTransformer which aggregates values and emits when it sees a value
+/// on [_trigger].
+///
+/// If there are no pending values when [_trigger] emits the first value on the
+/// source Stream will immediately flow through. Otherwise, the pending values
+/// and released when [_trigger] emits.
+class _Buffer<T, R> implements StreamTransformer<T, R> {
+  final Stream _trigger;
+  final _Collect _collect;
+
+  _Buffer(this._trigger, this._collect);
+
+  @override
+  Stream<R> bind(Stream<T> values) {
+    StreamController<R> controller;
+    if (values.isBroadcast) {
+      controller = new StreamController<R>.broadcast();
+    } else {
+      controller = new StreamController<R>();
+    }
+
+    R currentResults;
+    bool waitingForValue = false;
+    StreamSubscription valuesSub;
+    StreamSubscription triggerSub;
+
+    cancelValues() {
+      var sub = valuesSub;
+      valuesSub = null;
+      return sub?.cancel() ?? new Future.value();
+    }
+
+    cancelTrigger() {
+      var sub = triggerSub;
+      triggerSub = null;
+      return sub?.cancel() ?? new Future.value();
+    }
+
+    closeController() {
+      var ctl = controller;
+      controller = null;
+      return ctl?.close() ?? new Future.value();
+    }
+
+    controller.onListen = () {
+      emit() {
+        controller.add(currentResults);
+        currentResults = null;
+      }
+
+      valuesSub = values.listen(
+          (T value) {
+            currentResults = _collect(value, currentResults);
+            if (waitingForValue) {
+              emit();
+              waitingForValue = false;
+            }
+          },
+          onError: controller.addError,
+          onDone: () {
+            valuesSub = null;
+          });
+      triggerSub = _trigger.listen(
+          (_) {
+            if (currentResults == null) {
+              waitingForValue = true;
+              return;
+            }
+            emit();
+            if (valuesSub == null) {
+              controller.close();
+              cancelTrigger();
+            }
+          },
+          onError: controller.addError,
+          onDone: () async {
+            cancelValues();
+            closeController();
+          });
+    };
+
+    // Forward methods from listener
+    if (!values.isBroadcast) {
+      controller.onPause = () {
+        valuesSub?.pause();
+        triggerSub?.pause();
+      };
+      controller.onResume = () {
+        valuesSub?.resume();
+        triggerSub?.resume();
+      };
+    }
+    controller.onCancel = () => Future.wait([cancelValues(), cancelTrigger()]);
+    return controller.stream;
+  }
+}

--- a/lib/src/stream_transformers/buffer.dart
+++ b/lib/src/stream_transformers/buffer.dart
@@ -49,7 +49,7 @@ class _Buffer<T, R> implements StreamTransformer<T, R> {
     }
 
     R currentResults;
-    bool waitingForValue = false;
+    bool waitingForTrigger = true;
     StreamSubscription valuesSub;
     StreamSubscription triggerSub;
 
@@ -78,9 +78,9 @@ class _Buffer<T, R> implements StreamTransformer<T, R> {
 
     onValue(T value) {
       currentResults = _collect(value, currentResults);
-      if (waitingForValue) {
+      if (!waitingForTrigger) {
         emit();
-        waitingForValue = false;
+        waitingForTrigger = true;
       }
     }
 
@@ -94,7 +94,7 @@ class _Buffer<T, R> implements StreamTransformer<T, R> {
 
     onTrigger(_) {
       if (currentResults == null) {
-        waitingForValue = true;
+        waitingForTrigger = false;
         return;
       }
       emit();

--- a/lib/stream_transformers.dart
+++ b/lib/stream_transformers.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+@experimental
+library async.stream_transformers;
+
+import 'package:meta/meta.dart';
+
+export 'src/stream_transformers/buffer.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async
 dependencies:
   collection: "^1.5.0"
+  meta: ^1.0.5
 dev_dependencies:
   fake_async: "^0.1.2"
   stack_trace: "^1.0.0"

--- a/test/stream_transformers/buffer_test.dart
+++ b/test/stream_transformers/buffer_test.dart
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/stream_transformers/buffer_test.dart
+++ b/test/stream_transformers/buffer_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:async/stream_transformers.dart';
+
+void main() {
+  test('does not emit before `trigger`', () async {
+    var trigger = new StreamController();
+    var values = new Stream.fromIterable([1, 2, 3]);
+    var hasEmitted = false;
+    values.transform(buffer(trigger.stream)).listen((_) {
+      hasEmitted = true;
+    });
+    await new Future(() {});
+    expect(hasEmitted, false);
+    trigger.add(null);
+    await new Future(() {});
+    expect(hasEmitted, true);
+  });
+
+  test('emits immediately if trigger emits before a value', () async {
+    var trigger = new StreamController();
+    var values = new StreamController();
+    trigger.add(null);
+    var hasEmitted = false;
+    values.stream.transform(buffer(trigger.stream)).listen((_) {
+      hasEmitted = true;
+    });
+    values.add(1);
+    await new Future(() {});
+    expect(hasEmitted, true);
+  });
+
+  test('cancels value subscription when output canceled', () async {
+    var trigger = new StreamController();
+    var valuesCanceled = false;
+    var values = new StreamController()
+      ..onCancel = () {
+        valuesCanceled = true;
+      };
+    var subscription =
+        values.stream.transform(buffer(trigger.stream)).listen((_) {});
+    subscription.cancel();
+    expect(valuesCanceled, true);
+  });
+
+  test('cancels trigger subscription when output canceled', () async {
+    var triggerCanceled = false;
+    var trigger = new StreamController()
+      ..onCancel = () {
+        triggerCanceled = true;
+      };
+    var subscription =
+        new Stream.empty().transform(buffer(trigger.stream)).listen((_) {});
+    subscription.cancel();
+    expect(triggerCanceled, true);
+  });
+
+  test('output stream ends when trigger ends', () async {
+    var trigger = new StreamController();
+    var isDone = false;
+    _infiniteValues().transform(buffer(trigger.stream)).listen((_) {},
+        onDone: () {
+      isDone = true;
+    });
+    trigger.close();
+
+    await new Future(() {});
+    expect(isDone, true);
+  });
+
+  test('closes when trigger closes', () async {
+    var trigger = new StreamController();
+    var outputClosed = false;
+    _infiniteValues().transform(buffer(trigger.stream)).listen((_) {},
+        onDone: () {
+      outputClosed = true;
+    });
+    await trigger.close();
+    await new Future(() {});
+    expect(outputClosed, true);
+  });
+
+  test('closes after outputting final values when source closes', () async {
+    var trigger = new StreamController();
+    var values = new StreamController();
+    var outputClosed = false;
+    values.stream.transform(buffer(trigger.stream)).listen((_) {}, onDone: () {
+      outputClosed = true;
+    });
+    values.add(1);
+    await values.close();
+    expect(outputClosed, false);
+    trigger.add(null);
+    await new Future(() {});
+    expect(outputClosed, true);
+  });
+
+  test('closes immediately if there are no pending values when source closes',
+      () async {
+    var trigger = new StreamController();
+    var values = new StreamController();
+    var outputClosed = false;
+    values.stream.transform(buffer(trigger.stream)).listen((_) {}, onDone: () {
+      outputClosed = true;
+    });
+    await values.close();
+    expect(outputClosed, true);
+  });
+}
+
+Stream _infiniteValues() async* {
+  while (true) {
+    yield '';
+    await new Future(() {});
+  }
+}

--- a/test/stream_transformers/buffer_test.dart
+++ b/test/stream_transformers/buffer_test.dart
@@ -59,8 +59,9 @@ void main() {
 
   test('output stream ends when trigger ends', () async {
     var trigger = new StreamController();
+    var values = new StreamController();
     var isDone = false;
-    _infiniteValues().transform(buffer(trigger.stream)).listen((_) {},
+    values.stream.transform(buffer(trigger.stream)).listen((_) {},
         onDone: () {
       isDone = true;
     });
@@ -72,8 +73,9 @@ void main() {
 
   test('closes when trigger closes', () async {
     var trigger = new StreamController();
+    var values = new StreamController();
     var outputClosed = false;
-    _infiniteValues().transform(buffer(trigger.stream)).listen((_) {},
+    values.stream.transform(buffer(trigger.stream)).listen((_) {},
         onDone: () {
       outputClosed = true;
     });
@@ -106,13 +108,31 @@ void main() {
       outputClosed = true;
     });
     await values.close();
+    await new Future(() {});
     expect(outputClosed, true);
   });
-}
 
-Stream _infiniteValues() async* {
-  while (true) {
-    yield '';
+  test('forwards errors from trigger', () async {
+    var trigger = new StreamController();
+    var values = new StreamController();
+    var hasError = false;
+    values.stream.transform(buffer(trigger.stream)).listen((_) {}, onError: (_) {
+      hasError = true;
+    });
+    trigger.addError(null);
     await new Future(() {});
-  }
+    expect(hasError, true);
+  });
+
+  test('forwards errors from values', () async {
+    var trigger = new StreamController();
+    var values = new StreamController();
+    var hasError = false;
+    values.stream.transform(buffer(trigger.stream)).listen((_) {}, onError: (_) {
+      hasError = true;
+    });
+    values.addError(null);
+    await new Future(() {});
+    expect(hasError, true);
+  });
 }

--- a/test/stream_transformers/buffer_test.dart
+++ b/test/stream_transformers/buffer_test.dart
@@ -67,6 +67,22 @@ void main() {
           ]);
         });
 
+        test('groups values between trigger', () async {
+          values.add(1);
+          values.add(2);
+          await new Future(() {});
+          trigger.add(null);
+          values.add(3);
+          values.add(4);
+          await new Future(() {});
+          trigger.add(null);
+          await new Future(() {});
+          expect(emittedValues, [
+            [1, 2],
+            [3, 4]
+          ]);
+        });
+
         test('cancels value subscription when output canceled', () async {
           expect(valuesCanceled, false);
           subscription.cancel();


### PR DESCRIPTION
- Add stream_transformers library marked `@experimental` so we can
  iterate a bit on the APIs.
- Add `_Buffer` implementation which can collect values from a source
  stream and only emit them when a 'trigger' stream fires.
- Add top level method `buffer` which instantiates the `_Buffer` class.
  The stream transformers in this library will all be exposed as a top
  level method.