### PR TITLE
Updates for Dart 2.0 core library changes (wave 2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 * Add support for Dart 2.0 library changes to Stream and StreamTransformer.
   Changed classes that implement `StreamTransformer` to extend
   `StreamTransformerBase`, and changed signatures of `firstWhere`, `lastWhere`,
-  and `singleWhere` on classes extending `Stream`.  See also
-  https://github.com/dart-lang/sdk/issues/31847
+  and `singleWhere` on classes extending `Stream`.  See
+  also [issue 31847][sdk#31847].
+
+  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 
 ## 2.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.4
+
+* Add support for Dart 2.0 library changes to Stream and StreamTransformer.
+  Changed classes that implement `StreamTransformer` to extend
+  `StreamTransformerBase`, and changed signatures of `firstWhere`, `lastWhere`,
+  and `singleWhere` on classes extending `Stream`.  See also
+  https://github.com/dart-lang/sdk/issues/31847
+
 ## 2.0.3
 
 * Fix a bug in `StreamQueue.startTransaction()` and related methods when

--- a/lib/src/result/capture_transformer.dart
+++ b/lib/src/result/capture_transformer.dart
@@ -11,7 +11,7 @@ import 'capture_sink.dart';
 ///
 /// The result of the transformation is a stream of [Result] values and no
 /// error events. Exposed by [Result.captureStream].
-class CaptureStreamTransformer<T> implements StreamTransformer<T, Result<T>> {
+class CaptureStreamTransformer<T> extends StreamTransformerBase<T, Result<T>> {
   const CaptureStreamTransformer();
 
   Stream<Result<T>> bind(Stream<T> source) {

--- a/lib/src/result/release_transformer.dart
+++ b/lib/src/result/release_transformer.dart
@@ -8,7 +8,7 @@ import 'result.dart';
 import 'release_sink.dart';
 
 /// A transformer that releases result events as data and error events.
-class ReleaseStreamTransformer<T> implements StreamTransformer<Result<T>, T> {
+class ReleaseStreamTransformer<T> extends StreamTransformerBase<Result<T>, T> {
   const ReleaseStreamTransformer();
 
   Stream<T> bind(Stream<Result<T>> source) {

--- a/lib/src/single_subscription_transformer.dart
+++ b/lib/src/single_subscription_transformer.dart
@@ -13,7 +13,7 @@ import 'dart:async';
 /// This also casts the source stream's events to type `T`. If the cast fails,
 /// the result stream will emit a [CastError]. This behavior is deprecated, and
 /// should not be relied upon.
-class SingleSubscriptionTransformer<S, T> implements StreamTransformer<S, T> {
+class SingleSubscriptionTransformer<S, T> extends StreamTransformerBase<S, T> {
   const SingleSubscriptionTransformer();
 
   Stream<T> bind(Stream<S> stream) {

--- a/lib/src/typed/stream.dart
+++ b/lib/src/typed/stream.dart
@@ -56,15 +56,15 @@ class TypeSafeStream<T> extends Stream<T> {
   Future<T> firstWhere(bool test(T element),
           {Object defaultValue(), T orElse()}) =>
       _stream.firstWhere(_validateType(test),
-          defaultValue: defaultValue ?? orElse);
+          defaultValue: defaultValue, orElse: orElse);
 
   Future<T> lastWhere(bool test(T element),
           {Object defaultValue(), T orElse()}) =>
       _stream.lastWhere(_validateType(test),
-          defaultValue: defaultValue ?? orElse);
+          defaultValue: defaultValue, orElse: orElse);
 
   Future<T> singleWhere(bool test(T element), {T orElse()}) async =>
-      (await _stream.singleWhere(_validateType(test))) ?? orElse();
+      await _stream.singleWhere(_validateType(test), orElse: orElse);
 
   Future<S> fold<S>(S initialValue, S combine(S previous, T element)) =>
       _stream.fold(

--- a/lib/src/typed/stream.dart
+++ b/lib/src/typed/stream.dart
@@ -53,14 +53,18 @@ class TypeSafeStream<T> extends Stream<T> {
   Stream<S> expand<S>(Iterable<S> convert(T value)) =>
       _stream.expand(_validateType(convert));
 
-  Future firstWhere(bool test(T element), {Object defaultValue()}) =>
-      _stream.firstWhere(_validateType(test), defaultValue: defaultValue);
+  Future<T> firstWhere(bool test(T element),
+          {Object defaultValue(), T orElse()}) =>
+      _stream.firstWhere(_validateType(test),
+          defaultValue: defaultValue ?? orElse);
 
-  Future lastWhere(bool test(T element), {Object defaultValue()}) =>
-      _stream.lastWhere(_validateType(test), defaultValue: defaultValue);
+  Future<T> lastWhere(bool test(T element),
+          {Object defaultValue(), T orElse()}) =>
+      _stream.lastWhere(_validateType(test),
+          defaultValue: defaultValue ?? orElse);
 
-  Future<T> singleWhere(bool test(T element)) async =>
-      (await _stream.singleWhere(_validateType(test))) as T;
+  Future<T> singleWhere(bool test(T element), {T orElse()}) async =>
+      (await _stream.singleWhere(_validateType(test))) ?? orElse();
 
   Future<S> fold<S>(S initialValue, S combine(S previous, T element)) =>
       _stream.fold(

--- a/lib/src/typed_stream_transformer.dart
+++ b/lib/src/typed_stream_transformer.dart
@@ -20,7 +20,7 @@ StreamTransformer<S, T> typedStreamTransformer<S, T>(
 
 /// A wrapper that coerces the type of the stream returned by an inner
 /// transformer.
-class _TypeSafeStreamTransformer<S, T> implements StreamTransformer<S, T> {
+class _TypeSafeStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   final StreamTransformer _inner;
 
   _TypeSafeStreamTransformer(this._inner);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async
 environment:
-  sdk: ">=2.0.0-dev.20.0 <2.0.0"
+  sdk: ">=2.0.0-dev.23.0 <2.0.0"
 dependencies:
   collection: "^1.5.0"
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: async
-version: 2.0.3
+version: 2.0.4
 author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async
 environment:
-  sdk: ">=2.0.0-dev.15.0 <2.0.0"
+  sdk: ">=2.0.0-dev.20.0 <2.0.0"
 dependencies:
   collection: "^1.5.0"
 dev_dependencies:


### PR DESCRIPTION
This makes the initial changes necessary to make this package compatible with the corelib wave 2.2. changes.  See https://github.com/dart-lang/sdk/issues/31847 for more details.