### PR TITLE
Add deps for build_runner

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dev_dependencies:
   fake_async: "^0.1.2"
   stack_trace: "^1.0.0"
   test: "^0.12.0"
+  # For building and testing with DDC
   build_runner: ^0.7.11
   build_web_compilers: ^0.3.1
   build_test: ^0.10.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,6 @@ dev_dependencies:
   fake_async: "^0.1.2"
   stack_trace: "^1.0.0"
   test: "^0.12.0"
+  build_runner: ^0.7.11
+  build_web_compilers: ^0.3.1
+  build_test: ^0.10.1


### PR DESCRIPTION
Towards #48

Allows us to run `pub run build_runner test -- -p chrome` to test with
DDC. Exposes issues with the package and with tests so not enabling on
Travis for now.