### PR TITLE
Enable prefer_typing_uninitialized_variables

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,7 @@
 analyzer:
   strong-mode: true
+  errors:
+    todo: ignore
+linter:
+  rules:
+    - prefer_typing_uninitialized_variables

--- a/lib/src/result/error.dart
+++ b/lib/src/result/error.dart
@@ -10,7 +10,7 @@ import 'value.dart';
 /// A result representing a thrown error.
 class ErrorResult implements Result<Null> {
   /// The error object that was thrown.
-  final error;
+  final Object error;
 
   /// The stack trace corresponding to where [error] was thrown.
   final StackTrace stackTrace;

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -98,7 +98,7 @@ abstract class Result<T> {
   static Future<List<Result<T>>> captureAll<T>(Iterable<FutureOr<T>> elements) {
     var results = <Result<T>>[];
     int pending = 0;
-    var completer;
+    Completer<List<Result<T>>> completer;
     for (var element in elements) {
       if (element is Future<T>) {
         int i = results.length;

--- a/lib/src/single_subscription_transformer.dart
+++ b/lib/src/single_subscription_transformer.dart
@@ -17,7 +17,7 @@ class SingleSubscriptionTransformer<S, T> extends StreamTransformerBase<S, T> {
   const SingleSubscriptionTransformer();
 
   Stream<T> bind(Stream<S> stream) {
-    var subscription;
+    StreamSubscription<S> subscription;
     var controller = new StreamController<T>(
         sync: true, onCancel: () => subscription.cancel());
     subscription = stream.listen((value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: async
-version: 2.0.7
+version: 2.0.8-dev
 author: Dart Team <misc@dartlang.org>
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async
 environment:
   sdk: ">=2.0.0-dev.23.0 <2.0.0"
 dependencies:
-  collection: "^1.5.0"
+  collection: ^1.5.0
 dev_dependencies:
-  fake_async: ">=0.1.2 <2.0.0"
-  stack_trace: "^1.0.0"
-  test: "^0.12.0"
+  fake_async: ^1.0.0
+  stack_trace: ^1.0.0
+  test: ^1.0.0
   # For building and testing with DDC
-  build_runner: ^0.7.11
-  build_web_compilers: ^0.3.1
+  build_runner: ^0.8.0
+  build_web_compilers: ^0.4.0
   build_test: ^0.10.1

--- a/test/async_memoizer_test.dart
+++ b/test/async_memoizer_test.dart
@@ -6,7 +6,7 @@ import 'package:async/async.dart';
 import 'package:test/test.dart';
 
 main() {
-  var cache;
+  AsyncMemoizer cache;
   setUp(() => cache = new AsyncMemoizer());
 
   test("runs the function only the first time runOnce() is called", () async {

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -11,7 +11,7 @@ import 'utils.dart';
 
 void main() {
   group("without being canceled", () {
-    var completer;
+    CancelableCompleter completer;
     setUp(() {
       completer =
           new CancelableCompleter(onCancel: expectAsync0(() {}, count: 0));
@@ -118,7 +118,7 @@ void main() {
 
     test("fires onCancel", () {
       var canceled = false;
-      var completer;
+      CancelableCompleter completer;
       completer = new CancelableCompleter(onCancel: expectAsync0(() {
         expect(completer.isCanceled, isTrue);
         canceled = true;

--- a/test/future_group_test.dart
+++ b/test/future_group_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  var futureGroup;
+  FutureGroup futureGroup;
   setUp(() {
     futureGroup = new FutureGroup();
   });

--- a/test/lazy_stream_test.dart
+++ b/test/lazy_stream_test.dart
@@ -96,7 +96,7 @@ main() {
   });
 
   test("a lazy stream can't be listened to from within its callback", () {
-    var stream;
+    LazyStream stream;
     stream = new LazyStream(expectAsync0(() {
       expect(() => stream.listen(null), throwsStateError);
       return new Stream.empty();

--- a/test/result/result_future_test.dart
+++ b/test/result/result_future_test.dart
@@ -9,8 +9,8 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var completer;
-  var future;
+  Completer completer;
+  ResultFuture future;
   setUp(() {
     completer = new Completer();
     future = new ResultFuture(completer.future);

--- a/test/result/result_test.dart
+++ b/test/result/result_test.dart
@@ -301,12 +301,17 @@ void main() {
 
   test("handle neither unary nor binary", () {
     ErrorResult result = new Result.error("error", stack);
-    expect(() => result.handle(() => fail("unreachable")), throws);
-    expect(() => result.handle((a, b, c) => fail("unreachable")), throws);
-    expect(() => result.handle((a, b, {c}) => fail("unreachable")), throws);
-    expect(() => result.handle((a, {b}) => fail("unreachable")), throws);
-    expect(() => result.handle(({a, b}) => fail("unreachable")), throws);
-    expect(() => result.handle(({a}) => fail("unreachable")), throws);
+    expect(() => result.handle(() => fail("unreachable")), throwsA(anything));
+    expect(() => result.handle((a, b, c) => fail("unreachable")),
+        throwsA(anything));
+    expect(() => result.handle((a, b, {c}) => fail("unreachable")),
+        throwsA(anything));
+    expect(() => result.handle((a, {b}) => fail("unreachable")),
+        throwsA(anything));
+    expect(() => result.handle(({a, b}) => fail("unreachable")),
+        throwsA(anything));
+    expect(
+        () => result.handle(({a}) => fail("unreachable")), throwsA(anything));
   });
 }
 

--- a/test/stream_completer_test.dart
+++ b/test/stream_completer_test.dart
@@ -77,7 +77,7 @@ main() {
     var completer = new StreamCompleter();
     var lastEvent = -1;
     var controller = new StreamController();
-    var subscription;
+    StreamSubscription subscription;
     subscription = completer.stream.listen((value) {
       expect(value, lessThan(3));
       lastEvent = value;

--- a/test/stream_group_test.dart
+++ b/test/stream_group_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 main() {
   group("single-subscription", () {
-    var streamGroup;
+    StreamGroup<String> streamGroup;
     setUp(() {
       streamGroup = new StreamGroup<String>();
     });
@@ -250,7 +250,7 @@ main() {
   });
 
   group("broadcast", () {
-    var streamGroup;
+    StreamGroup<String> streamGroup;
     setUp(() {
       streamGroup = new StreamGroup<String>.broadcast();
     });
@@ -439,7 +439,7 @@ main() {
 }
 
 void regardlessOfType(StreamGroup<String> newStreamGroup()) {
-  var streamGroup;
+  StreamGroup<String> streamGroup;
   setUp(() {
     streamGroup = newStreamGroup();
   });

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -406,7 +406,7 @@ main() {
       expect(controller.hasListener, isTrue);
       expect(controller.isPaused, isFalse);
 
-      var lastEvent;
+      dynamic lastEvent;
       subscription.onData((value) => lastEvent = value);
 
       controller.add(2);
@@ -445,7 +445,7 @@ main() {
       expect(await events.peek, 4);
       expect(await events.next, 4);
       // Throws at end.
-      expect(events.peek, throws);
+      expect(events.peek, throwsA(anything));
       await events.cancel();
     });
     test("multiple requests at the same time", () async {
@@ -610,7 +610,7 @@ main() {
       var controller = new StreamController<int>();
       var events = new StreamQueue<int>(controller.stream);
 
-      var hasNext;
+      bool hasNext;
       events.hasNext.then((result) {
         hasNext = result;
       });
@@ -626,7 +626,7 @@ main() {
       var controller = new StreamController<int>();
       var events = new StreamQueue<int>(controller.stream);
 
-      var hasNext;
+      bool hasNext;
       events.hasNext.then((result) {
         hasNext = result;
       });

--- a/test/stream_sink_completer_test.dart
+++ b/test/stream_sink_completer_test.dart
@@ -10,7 +10,7 @@ import "package:test/test.dart";
 import "utils.dart";
 
 main() {
-  var completer;
+  StreamSinkCompleter completer;
   setUp(() {
     completer = new StreamSinkCompleter();
   });

--- a/test/stream_sink_transformer_test.dart
+++ b/test/stream_sink_transformer_test.dart
@@ -10,7 +10,7 @@ import "package:test/test.dart";
 import "utils.dart";
 
 void main() {
-  var controller;
+  StreamController controller;
   setUp(() {
     controller = new StreamController();
   });

--- a/test/stream_splitter_test.dart
+++ b/test/stream_splitter_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 main() {
   StreamController<int> controller;
-  var splitter;
+  StreamSplitter splitter;
   setUp(() {
     controller = new StreamController<int>();
     splitter = new StreamSplitter<int>(controller.stream);

--- a/test/stream_zip_test.dart
+++ b/test/stream_zip_test.dart
@@ -307,7 +307,7 @@ main() {
     var s2 = new Stream.fromIterable([1, 3, 5, 7]);
     var sz = new StreamZip([s1, s2]);
     int ctr = 0;
-    var sub;
+    StreamSubscription sub;
     sub = sz.listen(expectAsync1((v) {
       expect(v, equals([ctr * 2, ctr * 2 + 1]));
       if (ctr == 1) {

--- a/test/subscription_stream_test.dart
+++ b/test/subscription_stream_test.dart
@@ -40,7 +40,7 @@ main() {
     var sourceSubscription = stream.listen(null);
     var subscriptionStream = new SubscriptionStream<int>(sourceSubscription);
     var subscription = subscriptionStream.listen(null);
-    expect(() => subscriptionStream.listen(null), throws);
+    expect(() => subscriptionStream.listen(null), throwsA(anything));
     await subscription.cancel();
   });
 
@@ -49,7 +49,7 @@ main() {
     var sourceSubscription = controller.stream.listen(null);
     var subscriptionStream = new SubscriptionStream(sourceSubscription);
     expect(controller.isPaused, isTrue);
-    var lastEvent;
+    dynamic lastEvent;
     var subscription = subscriptionStream.listen((value) {
       lastEvent = value;
     });
@@ -72,8 +72,8 @@ main() {
   group("cancelOnError source:", () {
     for (var sourceCancels in [false, true]) {
       group("${sourceCancels ? "yes" : "no"}:", () {
-        var subscriptionStream;
-        var onCancel; // Completes if source stream is canceled before done.
+        SubscriptionStream subscriptionStream;
+        Future onCancel; // Completes if source stream is canceled before done.
         setUp(() {
           var cancelCompleter = new Completer();
           var source = createErrorStream(cancelCompleter);
@@ -142,7 +142,7 @@ main() {
 
           var subscription =
               subscriptionStream.listen(null, cancelOnError: cancelOnError);
-          expect(subscription.asFuture(), throws);
+          expect(subscription.asFuture(), throwsA(anything));
         });
       });
     }

--- a/test/typed_wrapper/future_test.dart
+++ b/test/typed_wrapper/future_test.dart
@@ -11,7 +11,7 @@ import '../utils.dart';
 
 void main() {
   group("with valid types, forwards", () {
-    var wrapper;
+    TypeSafeFuture<int> wrapper;
     TypeSafeFuture<int> errorWrapper;
     setUp(() {
       wrapper = new TypeSafeFuture<int>(new Future<Object>.value(12));
@@ -62,7 +62,7 @@ void main() {
       expect(
           new TypeSafeFuture<int>(new Completer<Object>().future)
               .timeout(Duration.zero),
-          throwsA(new isInstanceOf<TimeoutException>()));
+          throwsA(new TypeMatcher<TimeoutException>()));
 
       expect(
           new TypeSafeFuture<int>(new Completer<Object>().future)

--- a/test/typed_wrapper/stream_subscription_test.dart
+++ b/test/typed_wrapper/stream_subscription_test.dart
@@ -11,9 +11,9 @@ import '../utils.dart';
 
 void main() {
   group("with valid types, forwards", () {
-    var controller;
-    var wrapper;
-    var isCanceled;
+    StreamController controller;
+    StreamSubscription wrapper;
+    bool isCanceled;
     setUp(() {
       controller = new StreamController<Object>(onCancel: () {
         isCanceled = true;
@@ -68,9 +68,9 @@ void main() {
   });
 
   group("with invalid types,", () {
-    var controller;
-    var wrapper;
-    var isCanceled;
+    StreamController controller;
+    StreamSubscription wrapper;
+    bool isCanceled;
     setUp(() {
       controller = new StreamController<Object>(onCancel: () {
         isCanceled = true;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -38,10 +38,10 @@ Matcher throwsZoned(matcher) => predicate((callback) {
 
 /// A matcher that runs a callback in its own zone and asserts that that zone
 /// emits a [CastError].
-final throwsZonedCastError = throwsZoned(new isInstanceOf<CastError>());
+final throwsZonedCastError = throwsZoned(new TypeMatcher<CastError>());
 
 /// A matcher that matches a callback or future that throws a [CastError].
-final throwsCastError = throwsA(new isInstanceOf<CastError>());
+final throwsCastError = throwsA(new TypeMatcher<CastError>());
 
 /// A badly behaved stream which throws if it's ever listened to.
 ///


### PR DESCRIPTION
This helps rule out some possibilities for the new Dart 2 failure and is
good practice.

Also:
- Update dependencies on build and test packages.
- Ignore todo from the analysis server.
- Move off of deprecated APIs from test.