### PR TITLE
Fix places awaiting void, for dart 2.

### DIFF
--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -89,12 +89,13 @@ class AsyncCache<T> {
   }
 
   /// Removes any cached value.
-  void invalidate() {
+  Future invalidate() {
     _cachedValueFuture = null;
-    _cachedStreamSplitter?.close();
+    Future invalidate = _cachedStreamSplitter?.close();
     _cachedStreamSplitter = null;
     _stale?.cancel();
     _stale = null;
+    return invalidate;
   }
 
   void _startStaleTimer() {

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -37,19 +37,19 @@ class AsyncCache<T> {
   /// Fires when the cache should be considered stale.
   Timer _stale;
 
-  /// Creates a cache that invalidates after an in-flight request is complete.
-  ///
-  /// An ephemeral cache guarantees that a callback function will only be
-  /// executed at most once concurrently. This is useful for requests for which
-  /// data is updated frequently but stale data is acceptable.
-  factory AsyncCache.ephemeral() => new AsyncCache(Duration.zero);
-
   /// Creates a cache that invalidates its contents after [duration] has passed.
   ///
   /// The [duration] starts counting after the Future returned by [fetch]
   /// completes, or after the Stream returned by [fetchStream] emits a done
   /// event.
   AsyncCache(this._duration);
+
+  /// Creates a cache that invalidates after an in-flight request is complete.
+  ///
+  /// An ephemeral cache guarantees that a callback function will only be
+  /// executed at most once concurrently. This is useful for requests for which
+  /// data is updated frequently but stale data is acceptable.
+  factory AsyncCache.ephemeral() => new AsyncCache(Duration.zero);
 
   /// Returns a cached value from a previous call to [fetch], or runs [callback]
   /// to compute a new one.
@@ -89,13 +89,16 @@ class AsyncCache<T> {
   }
 
   /// Removes any cached value.
-  Future invalidate() {
+  Null invalidate() {
     _cachedValueFuture = null;
-    Future invalidate = _cachedStreamSplitter?.close();
+    // TODO: This does not await, but probably should.
+    _cachedStreamSplitter?.close();
     _cachedStreamSplitter = null;
     _stale?.cancel();
     _stale = null;
-    return invalidate;
+
+    // TODO: This does not return a future, but probably should.
+    return null;
   }
 
   void _startStaleTimer() {

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -89,16 +89,14 @@ class AsyncCache<T> {
   }
 
   /// Removes any cached value.
-  Null invalidate() {
+  void invalidate() {
+    // TODO: This does not return a future, but probably should.
     _cachedValueFuture = null;
     // TODO: This does not await, but probably should.
     _cachedStreamSplitter?.close();
     _cachedStreamSplitter = null;
     _stale?.cancel();
     _stale = null;
-
-    // TODO: This does not return a future, but probably should.
-    return null;
   }
 
   void _startStaleTimer() {

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -58,9 +58,9 @@ void main() {
     var timesCalled = 0;
     call() async => 'Called ${++timesCalled}';
     expect(await cache.fetch(call), 'Called 1');
-    await cache.invalidate();
+    cache.invalidate();
     expect(await cache.fetch(call), 'Called 2');
-    await cache.invalidate();
+    cache.invalidate();
     expect(await cache.fetch(call), 'Called 3');
   });
 
@@ -129,9 +129,9 @@ void main() {
     }
 
     expect(await cache.fetchStream(call).toList(), ['Called 1']);
-    await cache.invalidate();
+    cache.invalidate();
     expect(await cache.fetchStream(call).toList(), ['Called 2']);
-    await cache.invalidate();
+    cache.invalidate();
     expect(await cache.fetchStream(call).toList(), ['Called 3']);
   });
 

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -32,7 +32,7 @@ void main() {
     var completer = new Completer<String>();
     expect(cache.fetch(() => completer.future), completion('Expensive'));
     expect(cache.fetch(expectAsync0(() {}, count: 0)), completion('Expensive'));
-    await completer.complete('Expensive');
+    completer.complete('Expensive');
   });
 
   test('should fetch via a callback again when cache expires', () {

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -517,8 +517,8 @@ main() {
         expect(await events.next, 1);
         expect(controller.hasListener, isTrue);
 
-        events.cancel(immediate: true);
-        await expect(controller.hasListener, isFalse);
+        await events.cancel(immediate: true);
+        expect(controller.hasListener, isFalse);
       });
 
       test("cancels the underlying subscription when called before any event",

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -153,8 +153,8 @@ main() {
 
     test("multiple requests at the same time", () async {
       var events = new StreamQueue<int>(createStream());
-      var result = await Future.wait(
-          [events.next, events.next, events.next, events.next]);
+      var result = await Future
+          .wait([events.next, events.next, events.next, events.next]);
       expect(result, [1, 2, 3, 4]);
       await events.cancel();
     });

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -153,8 +153,8 @@ main() {
 
     test("multiple requests at the same time", () async {
       var events = new StreamQueue<int>(createStream());
-      var result = await Future
-          .wait([events.next, events.next, events.next, events.next]);
+      var result = await Future.wait(
+          [events.next, events.next, events.next, events.next]);
       expect(result, [1, 2, 3, 4]);
       await events.cancel();
     });


### PR DESCRIPTION
Looks like cache.invalidate does do some asynchronous stuff
(`splitter.close()`, but notably not `_stale.close()` which returns void).
Return the future for that stuff without changing its order of
operations.

Also some place awaiting `expect()` which appeared to be intended to be
awaiting `cancel()`, switching those still passes tests.