### PR TITLE
Implement RestartableTimer.tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Implement `RestartableTimer.tick`.
+
 ## 2.2.0
 
 * Add `then` to `CancelableOperation`.

--- a/lib/src/restartable_timer.dart
+++ b/lib/src/restartable_timer.dart
@@ -44,11 +44,11 @@ class RestartableTimer implements Timer {
     _timer.cancel();
   }
 
+  /// The number of durations preceding the most recent timer event on the most
+  /// recent countdown.
+  ///
+  /// Calls to [reset] will also reset the tick so subsequent tick values may
+  /// not be strictly larger than previous values.
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // See https://github.com/dart-lang/sdk/issues/31664
-  // ignore: override_on_non_overriding_getter
-  int get tick {
-    throw UnimplementedError("tick");
-  }
+  int get tick => _timer.tick;
 }

--- a/lib/src/restartable_timer.dart
+++ b/lib/src/restartable_timer.dart
@@ -25,9 +25,8 @@ class RestartableTimer implements Timer {
   ///
   /// The [callback] function is invoked after the given [duration]. Unlike a
   /// normal non-periodic [Timer], [callback] may be called more than once.
-  RestartableTimer(this._duration, this._callback) {
-    _timer = Timer(_duration, _callback);
-  }
+  RestartableTimer(this._duration, this._callback)
+      : _timer = Timer(_duration, _callback);
 
   bool get isActive => _timer.isActive;
 
@@ -49,6 +48,5 @@ class RestartableTimer implements Timer {
   ///
   /// Calls to [reset] will also reset the tick so subsequent tick values may
   /// not be strictly larger than previous values.
-  @override
   int get tick => _timer.tick;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.2.0
+version: 2.3.0
 
 description: Utility functions and classes related to the 'dart:async' library.
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
Closes #88

Extra cleanup:
- change a constructor body to an initializer list
- remove an `@override` annotation