### PR TITLE
Check ordering in StreamGroup.merege tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.4.0
+version: 2.4.1-dev
 
 description: Utility functions and classes related to the 'dart:async' library.
 author: Dart Team <misc@dartlang.org>

--- a/test/stream_group_test.dart
+++ b/test/stream_group_test.dart
@@ -422,7 +422,7 @@ main() {
     });
   });
 
-  test("merge() emits events from all components streams", () {
+  test("merge() emits events from all components streams", () async {
     var controller1 = StreamController<String>();
     var controller2 = StreamController<String>();
 
@@ -433,10 +433,10 @@ main() {
     controller2.add("second");
     controller2.close();
 
-    expect(merged.toList(), completion(unorderedEquals(["first", "second"])));
+    expect(await merged.toList(), ["first", "second"]);
   });
 
-  test("mergeBroadcast() emits events from all components streams", () {
+  test("mergeBroadcast() emits events from all components streams", () async {
     var controller1 = StreamController<String>();
     var controller2 = StreamController<String>();
 
@@ -450,7 +450,7 @@ main() {
 
     expect(merged.isBroadcast, isTrue);
 
-    expect(merged.toList(), completion(unorderedEquals(["first", "second"])));
+    expect(await merged.toList(), ["first", "second"]);
   });
 }
 


### PR DESCRIPTION
See https://github.com/dart-lang/async/pull/90#discussion_r331247755

Merged streams forward events synchronously so we do know that
guarantees that events keep their order when forwarded. Since it's not
necessary to allow for ordering changes drop the `unorderedEquals`.

Also refactor to async/await from a `completion` matcher.