### PR TITLE
Drop optional new from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.4.1-dev
+
 ## 2.4.0
 
 * Add `StreamGroup.mergeBroadcast()` utility.

--- a/lib/src/async_memoizer.dart
+++ b/lib/src/async_memoizer.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 ///
 /// ```dart
 /// class SomeResource {
-///   final _closeMemo = new AsyncMemoizer();
+///   final _closeMemo = AsyncMemoizer();
 ///
 ///   Future close() => _closeMemo.runOnce(() {
 ///     // ...

--- a/lib/src/null_stream_sink.dart
+++ b/lib/src/null_stream_sink.dart
@@ -12,16 +12,16 @@ import 'dart:async';
 /// been closed.
 ///
 /// This can be used when a sink is needed but no events are actually intended
-/// to be added. The [new NullStreamSink.error] constructor can be used to
+/// to be added. The [NullStreamSink.error] constructor can be used to
 /// represent errors when creating a sink, since [StreamSink.done] exposes sink
 /// errors. For example:
 ///
 /// ```dart
 /// StreamSink<List<int>> openForWrite(String filename) {
 ///   try {
-///     return new RandomAccessSink(new File(filename).openSync());
+///     return RandomAccessSink(File(filename).openSync());
 ///   } on IOException catch (error, stackTrace) {
-///     return new NullStreamSink.error(error, stackTrace);
+///     return NullStreamSink.error(error, stackTrace);
 ///   }
 /// }
 /// ```

--- a/lib/src/stream_group.dart
+++ b/lib/src/stream_group.dart
@@ -16,7 +16,7 @@ import 'dart:async';
 /// be single-subscription. In this case, if [stream] is paused or canceled, all
 /// streams in the group will likewise be paused or canceled, respectively.
 ///
-/// If the `StreamGroup` is constructed using [new StreamGroup.broadcast],
+/// If the `StreamGroup` is constructed using [StreamGroup.broadcast],
 /// [stream] will be a broadcast stream. In this case, the streams in the group
 /// will never be paused and single-subscription streams in the group will never
 /// be canceled. **Note that single-subscription streams in a broadcast group


### PR DESCRIPTION
- Remove `new` keyword in code samples.
- Remove `new` keyword in doc reference to named constructors.