### PR TITLE
Deprecate Delegating*.typed utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 2.4.1-dev
 
+* Deprecate `DelegatingStream.typed`. Use `Stream.cast` instead.
+* Deprecate `DelegatingStreamSubcription.typed` and
+  `DelegatingStreamConsumer.typed`. For each of these the `Stream` should be
+  cast to the correct type before being used.
+* Deprecate `DelegatingStreamSink.typed`. `DelegatingSink.typed`,
+  `DelegatingEventSink.typed`, `DelegatingStreamConsumer.typed`. For each of
+  these a new `StreamController` can be constructed to forward to the sink.
+  `StreamController<T>()..stream.cast<S>().pipe(sink)`
+* Deprecate `typedStreamTransformer`. Cast after transforming instead.
+* Deprecate `StreamSinkTransformer.typed` since there was no usage.
+
 ## 2.4.0
 
 * Add `StreamGroup.mergeBroadcast()` utility.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ computations.
   [`DelegatingEventSink`][DelegatingEventSink], and
   [`DelegatingStreamSink`][DelegatingStreamSink].
 
-  The delegating classes all have `.typed()` constructors which allow users to
-  cast the generic type parameters in a way that's safe for strong mode. For
-  example, if `future` is a `Future<dynamic>` and you know it actually contains an
-  `int`, you can write `DelegatingFuture.typed<int>(future)`.
-
 * The [`FutureGroup`][FutureGroup] class makes it easy to wait until a group of
   features that may change over time completes.
 

--- a/lib/src/delegate/event_sink.dart
+++ b/lib/src/delegate/event_sink.dart
@@ -22,6 +22,8 @@ class DelegatingEventSink<T> implements EventSink<T> {
   /// instance of `EventSink`, not `EventSink<T>`. This means that calls to
   /// [add] may throw a [CastError] if the argument type doesn't match the
   /// reified type of [sink].
+  @Deprecated(
+      'Use StreamController<T>(sync: true)..stream.cast<S>().pipe(sink)')
   static EventSink<T> typed<T>(EventSink sink) =>
       sink is EventSink<T> ? sink : DelegatingEventSink._(sink);
 

--- a/lib/src/delegate/sink.dart
+++ b/lib/src/delegate/sink.dart
@@ -20,6 +20,8 @@ class DelegatingSink<T> implements Sink<T> {
   /// instance of `Sink`, not `Sink<T>`. This means that calls to [add] may
   /// throw a [CastError] if the argument type doesn't match the reified type of
   /// [sink].
+  @Deprecated(
+      'Use StreamController<T>(sync: true)..stream.cast<S>().pipe(sink)')
   static Sink<T> typed<T>(Sink sink) =>
       sink is Sink<T> ? sink : DelegatingSink._(sink);
 

--- a/lib/src/delegate/stream.dart
+++ b/lib/src/delegate/stream.dart
@@ -21,5 +21,6 @@ class DelegatingStream<T> extends StreamView<T> {
   /// original generic type, by asserting that its events are instances of `T`
   /// whenever they're provided. If they're not, the stream throws a
   /// [CastError].
+  @Deprecated('Use stream.cast instead')
   static Stream<T> typed<T>(Stream stream) => stream.cast();
 }

--- a/lib/src/delegate/stream_consumer.dart
+++ b/lib/src/delegate/stream_consumer.dart
@@ -22,6 +22,8 @@ class DelegatingStreamConsumer<T> implements StreamConsumer<T> {
   /// instance of `StreamConsumer`, not `StreamConsumer<T>`. This means that
   /// calls to [addStream] may throw a [CastError] if the argument type doesn't
   /// match the reified type of [consumer].
+  @Deprecated(
+      'Use StreamController<T>(sync: true)..stream.cast<S>().pipe(sink)')
   static StreamConsumer<T> typed<T>(StreamConsumer consumer) =>
       consumer is StreamConsumer<T>
           ? consumer

--- a/lib/src/delegate/stream_sink.dart
+++ b/lib/src/delegate/stream_sink.dart
@@ -25,6 +25,8 @@ class DelegatingStreamSink<T> implements StreamSink<T> {
   /// of `StreamSink`, not `StreamSink<T>`. This means that calls to [add] may
   /// throw a [CastError] if the argument type doesn't match the reified type of
   /// [sink].
+  @Deprecated(
+      'Use StreamController<T>(sync: true)..stream.cast<S>().pipe(sink)')
   static StreamSink<T> typed<T>(StreamSink sink) =>
       sink is StreamSink<T> ? sink : DelegatingStreamSink._(sink);
 

--- a/lib/src/delegate/stream_subscription.dart
+++ b/lib/src/delegate/stream_subscription.dart
@@ -23,6 +23,8 @@ class DelegatingStreamSubscription<T> implements StreamSubscription<T> {
   /// regardless of its original generic type, by asserting that its events are
   /// instances of `T` whenever they're provided. If they're not, the
   /// subscription throws a [CastError].
+  @Deprecated('Use Stream.cast instead')
+  // TODO - Remove `TypeSafeStreamSubscription` and tests when removing this.
   static StreamSubscription<T> typed<T>(StreamSubscription subscription) =>
       subscription is StreamSubscription<T>
           ? subscription

--- a/lib/src/lazy_stream.dart
+++ b/lib/src/lazy_stream.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'delegate/stream.dart';
 import 'stream_completer.dart';
 import 'utils.dart';
 
@@ -40,11 +39,9 @@ class LazyStream<T> extends Stream<T> {
 
     Stream<T> stream;
     if (result is Future<Stream<T>>) {
-      stream = StreamCompleter.fromFuture(result.then((stream) {
-        return DelegatingStream.typed<T>(stream);
-      }));
+      stream = StreamCompleter.fromFuture(result);
     } else {
-      stream = DelegatingStream.typed<T>(result as Stream);
+      stream = result as Stream<T>;
     }
 
     return stream.listen(onData,

--- a/lib/src/stream_sink_transformer.dart
+++ b/lib/src/stream_sink_transformer.dart
@@ -53,6 +53,8 @@ abstract class StreamSinkTransformer<S, T> {
   /// This means that calls to [StreamSink.add] on the returned sink may throw a
   /// [CastError] if the argument type doesn't match the reified type of the
   /// sink.
+  @deprecated
+  // TODO remove TypeSafeStreamSinkTransformer
   static StreamSinkTransformer<S, T> typed<S, T>(
           StreamSinkTransformer transformer) =>
       transformer is StreamSinkTransformer<S, T>

--- a/lib/src/stream_sink_transformer/typed.dart
+++ b/lib/src/stream_sink_transformer/typed.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import '../delegate/stream_sink.dart';
 import '../stream_sink_transformer.dart';
 
 /// A wrapper that coerces the generic type of the sink returned by an inner
@@ -16,6 +15,6 @@ class TypeSafeStreamSinkTransformer<S, T>
   TypeSafeStreamSinkTransformer(this._inner);
 
   @override
-  StreamSink<S> bind(StreamSink<T> sink) =>
-      DelegatingStreamSink.typed(_inner.bind(sink));
+  StreamSink<S> bind(StreamSink<T> sink) => StreamController(sync: true)
+    ..stream.cast<dynamic>().pipe(_inner.bind(sink));
 }

--- a/lib/src/typed_stream_transformer.dart
+++ b/lib/src/typed_stream_transformer.dart
@@ -4,14 +4,13 @@
 
 import 'dart:async';
 
-import 'delegate/stream.dart';
-
 /// Creates a wrapper that coerces the type of [transformer].
 ///
 /// This soundly converts a [StreamTransformer] to a `StreamTransformer<S, T>`,
 /// regardless of its original generic type, by asserting that the events
 /// emitted by the transformed stream are instances of `T` whenever they're
 /// provided. If they're not, the stream throws a [CastError].
+@Deprecated('Use Stream.cast after binding a transformer instead')
 StreamTransformer<S, T> typedStreamTransformer<S, T>(
         StreamTransformer transformer) =>
     transformer is StreamTransformer<S, T>
@@ -26,6 +25,5 @@ class _TypeSafeStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   _TypeSafeStreamTransformer(this._inner);
 
   @override
-  Stream<T> bind(Stream<S> stream) =>
-      DelegatingStream.typed(_inner.bind(stream));
+  Stream<T> bind(Stream<S> stream) => _inner.bind(stream).cast();
 }


### PR DESCRIPTION
Towards #98 

Most of these have simpler or safer versions in Dart 2. The "Sink"
classes have a workaround which is ugly, but these also had nearly no
usage.