### PR TITLE
Cast use of StreamSubscription.cancel result through dynamic

### DIFF
--- a/test/subscription_stream_test.dart
+++ b/test/subscription_stream_test.dart
@@ -65,7 +65,7 @@ void main() {
     subscription.resume();
     expect(controller.isPaused, isFalse);
 
-    expect(await subscription.cancel(), 42);
+    expect(await subscription.cancel() as dynamic, 42);
     expect(controller.hasListener, isFalse);
   });
 


### PR DESCRIPTION
The breaking change described [here](https://github.com/dart-lang/sdk/issues/40676) changes the return type of StreamSubscription.cancel to `Future<void>` to make it clear that the result value is not intended to be meaningful.  Code that chooses to rely on the return value must now cast through `dynamic`.  