### PR TITLE
--null-safety fixes, make valueOrCancellation return a T?

### DIFF
--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -68,11 +68,8 @@ class CancelableOperation<T> {
   /// If this operation completes, this completes to the same result as [value].
   /// If this operation is cancelled, the returned future waits for the future
   /// returned by [cancel], then completes to [cancellationValue].
-  ///
-  /// If [T] is not nullable then [cancellationValue] must provide a valid
-  /// value, otherwise it will throw on cancellation.
-  Future<T> valueOrCancellation([T? cancellationValue]) {
-    var completer = Completer<T>.sync();
+  Future<T?> valueOrCancellation([T? cancellationValue]) {
+    var completer = Completer<T?>.sync();
     value.then((result) => completer.complete(result),
         onError: completer.completeError);
 
@@ -102,10 +99,11 @@ class CancelableOperation<T> {
     final completer =
         CancelableCompleter<R>(onCancel: propagateCancel ? cancel : null);
 
-    valueOrCancellation().then((T result) {
+    valueOrCancellation().then((T? result) {
       if (!completer.isCanceled) {
         if (isCompleted) {
-          completer.complete(Future<R>.sync(() => onValue(result)));
+          assert(result is T);
+          completer.complete(Future<R>.sync(() => onValue(result!)));
         } else if (onCancel != null) {
           completer.complete(Future<R>.sync(onCancel));
         } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependency_overrides:
   path:
     git:
       url: git://github.com/dart-lang/path.git
-      ref: null_safety_insert_workaround
+      ref: null_safety
   source_span:
     git:
       url: git://github.com/dart-lang/source_span.git
@@ -63,3 +63,13 @@ dependency_overrides:
       url: git://github.com/dart-lang/test.git
       ref: null_safety
       path: pkgs/test_api
+  test_core:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_core
+  test:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test

--- a/test/byte_collection_test.dart
+++ b/test/byte_collection_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:async/async.dart';
@@ -79,9 +78,8 @@ void main() {
       expect(sc.hasListener, isTrue);
       result.cancel();
       expect(sc.hasListener, isFalse); // Cancelled immediately.
-      var cancellationVal = Uint8List(0);
-      var replacement = await result.valueOrCancellation(cancellationVal);
-      expect(replacement, same(cancellationVal));
+      var replacement = await result.valueOrCancellation();
+      expect(replacement, isNull);
       await nextTimerTick();
       sc.close();
       await nextTimerTick();

--- a/test/byte_collection_test.dart
+++ b/test/byte_collection_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:async/async.dart';
@@ -78,8 +79,9 @@ void main() {
       expect(sc.hasListener, isTrue);
       result.cancel();
       expect(sc.hasListener, isFalse); // Cancelled immediately.
-      var replacement = await result.valueOrCancellation();
-      expect(replacement, isNull);
+      var cancellationVal = Uint8List(0);
+      var replacement = await result.valueOrCancellation(cancellationVal);
+      expect(replacement, same(cancellationVal));
       await nextTimerTick();
       sc.close();
       await nextTimerTick();

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -1046,6 +1046,9 @@ void main() {
       expect(events.withTransaction(expectAsync1((queue) async {
         expect(await queue.next, 2);
         throw 'oh no';
+        // TODO: Remove after https://github.com/dart-lang/sdk/issues/41156
+        // ignore: dead_code
+        return true;
       })), throwsA('oh no'));
 
       expect(events.next, completion(3));


### PR DESCRIPTION
This did result in one api change, which I think is for the better anyways. `CancelableOperation.valueOrCancellation` now has a return type of `T?`, where it would have previously thrown at runtime if you didn't provide a cancellation value.

Also added a workaround for https://github.com/dart-lang/sdk/issues/41156 in one of the tests.