### PR TITLE
Drop workaround for function type inference

### DIFF
--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -1046,9 +1046,6 @@ void main() {
       expect(events.withTransaction(expectAsync1((queue) async {
         expect(await queue.next, 2);
         throw 'oh no';
-        // TODO: Remove after https://github.com/dart-lang/sdk/issues/41156
-        // ignore: dead_code
-        return true;
       })), throwsA('oh no'));
 
       expect(events.next, completion(3));


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/41156 is fixed.