### PR TITLE
fix nnbd tests to run with strong null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,33 @@
 language: dart
 
 dart:
-  - dev
-  - 2.2.0
+ - be/raw/latest
 
-dart_task:
-  - test: --platform vm
-  - test: --platform chrome
-  - dartanalyzer
-  - dartfmt
+jobs:
+  include:
+    - stage: analyze_and_format
+      name: "Analyzer"
+      dart: be/raw/latest
+      os: linux
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
+    - stage: analyze_and_format
+      name: "Format"
+      dart: be/raw/latest
+      os: linux
+      script: dartfmt -n --set-exit-if-changed .
+    - stage: test
+      name: "Vm Tests"
+      dart: be/raw/latest
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p vm
+
+stages:
+  - analyze_and_format
+  - test
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master]
+  only: [master, null_safety]
 
 cache:
   directories:

--- a/lib/src/lazy_stream.dart
+++ b/lib/src/lazy_stream.dart
@@ -41,7 +41,7 @@ class LazyStream<T> extends Stream<T> {
     if (result is Future<Stream<T>>) {
       stream = StreamCompleter.fromFuture(result);
     } else {
-      stream = result as Stream<T>;
+      stream = result;
     }
 
     return stream.listen(onData,

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -112,7 +112,7 @@ abstract class Result<T> {
           }
         });
       } else {
-        results.add(Result<T>.value(element as T));
+        results.add(Result<T>.value(element));
       }
     }
     if (pending == 0) {

--- a/lib/src/single_subscription_transformer.dart
+++ b/lib/src/single_subscription_transformer.dart
@@ -11,7 +11,7 @@ import 'dart:async';
 /// listening to a stream as soon as it's bound.
 ///
 /// This also casts the source stream's events to type `T`. If the cast fails,
-/// the result stream will emit a [CastError]. This behavior is deprecated, and
+/// the result stream will emit a [TypeError]. This behavior is deprecated, and
 /// should not be relied upon.
 class SingleSubscriptionTransformer<S, T> extends StreamTransformerBase<S, T> {
   const SingleSubscriptionTransformer();
@@ -26,7 +26,7 @@ class SingleSubscriptionTransformer<S, T> extends StreamTransformerBase<S, T> {
       // type parameter and avoid this conversion.
       try {
         controller.add(value as T);
-      } on CastError catch (error, stackTrace) {
+      } on TypeError catch (error, stackTrace) {
         controller.addError(error, stackTrace);
       }
     }, onError: controller.addError, onDone: controller.close);

--- a/test/result/result_test.dart
+++ b/test/result/result_test.dart
@@ -72,7 +72,7 @@ void main() {
     var c = Completer<bool>();
     c.future.then((bool v) {
       fail('Unexpected value $v');
-    }, onError: expectAsync2((e, s) {
+    }).then<void>((_) {}, onError: expectAsync2((e, s) {
       expect(e, equals('BAD'));
       expect(s, same(stack));
     }));
@@ -109,7 +109,7 @@ void main() {
     Result<bool> result = ErrorResult('BAD', stack);
     result.asFuture.then((bool v) {
       fail('Unexpected value $v');
-    }, onError: expectAsync2((e, s) {
+    }).then<void>((_) {}, onError: expectAsync2((e, s) {
       expect(e, equals('BAD'));
       expect(s, same(stack));
     }));
@@ -154,7 +154,7 @@ void main() {
     var future = Future<Result<bool>>.value(Result<bool>.error('BAD', stack));
     Result.release(future).then((v) {
       fail('Unexpected value: $v');
-    }, onError: expectAsync2((e, s) {
+    }).then<void>((_) {}, onError: expectAsync2((e, s) {
       expect(e, equals('BAD'));
       expect(s, same(stack));
     }));
@@ -165,7 +165,7 @@ void main() {
     var future = Future<Result<bool>>.error('BAD', stack);
     Result.release(future).then((v) {
       fail('Unexpected value: $v');
-    }, onError: expectAsync2((e, s) {
+    }).then<void>((_) {}, onError: expectAsync2((e, s) {
       expect(e, equals('BAD'));
       expect(s, same(stack));
     }));

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -37,11 +37,11 @@ Matcher throwsZoned(matcher) => predicate((void Function() callback) {
     });
 
 /// A matcher that runs a callback in its own zone and asserts that that zone
-/// emits a [CastError].
-final throwsZonedCastError = throwsZoned(TypeMatcher<CastError>());
+/// emits a [TypeError].
+final throwsZonedCastError = throwsZoned(TypeMatcher<TypeError>());
 
-/// A matcher that matches a callback or future that throws a [CastError].
-final throwsCastError = throwsA(TypeMatcher<CastError>());
+/// A matcher that matches a callback or future that throws a [TypeError].
+final throwsCastError = throwsA(TypeMatcher<TypeError>());
 
 /// A badly behaved stream which throws if it's ever listened to.
 ///


### PR DESCRIPTION
Same issue as package:pool, error handlers need to return the right type.