### PR TITLE
Make StreamQueue start listening immediately to broadcast streams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+* `StreamQueue` starts listening immediately to broadcast strings.
+
 ## 2.4.1
 
 * Deprecate `DelegatingStream.typed`. Use `Stream.cast` instead.

--- a/lib/src/stream_queue.dart
+++ b/lib/src/stream_queue.dart
@@ -118,7 +118,13 @@ class StreamQueue<T> {
   factory StreamQueue(Stream<T> source) => StreamQueue._(source);
 
   // Private generative constructor to avoid subclasses.
-  StreamQueue._(this._source);
+  StreamQueue._(this._source) {
+    // Start listening immediately if we could otherwise lose events.
+    if (_source.isBroadcast) {
+      _ensureListening();
+      _pause();
+    }
+  }
 
   /// Asks if the stream has any more events.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.4.1
+version: 2.4.2
 
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async


### PR DESCRIPTION
When a `StreamQueue` is created for a broadcast stream, it didn't use to listen to the stream immediately, which means that any events sent before the first call to `next` (or any other queue request) would be silently lost. That makes an initial `peek` operation change the behavior of the queue, which is confusing to users.