### PR TITLE
Fix error in CancelableOperation.then

### DIFF
--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -103,7 +103,7 @@ class CancelableOperation<T> {
       if (!completer.isCanceled) {
         if (isCompleted) {
           assert(result is T);
-          completer.complete(Future.sync(() => onValue(result!)));
+          completer.complete(Future.sync(() => onValue(result as T)));
         } else if (onCancel != null) {
           completer.complete(Future.sync(onCancel));
         } else {


### PR DESCRIPTION
Replace a dynamic null check with a dynamic type cast, since the target type may be nullable.