### PR TITLE
Invalidate async cache on exception

### DIFF
--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -60,15 +60,12 @@ class AsyncCache<T> {
     if (_cachedStreamSplitter != null) {
       throw StateError('Previously used to cache via `fetchStream`');
     }
-    if (_cachedValueFuture == null) {
-      _cachedValueFuture = callback();
-      try {
-        await _cachedValueFuture;
-      } finally {
-        _startStaleTimer();
-      }
+    final result = _cachedValueFuture ??= callback();
+    try {
+      return await result;
+    } finally {
+      _startStaleTimer();
     }
-    return _cachedValueFuture!;
   }
 
   /// Returns a cached stream from a previous call to [fetchStream], or runs

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -62,8 +62,11 @@ class AsyncCache<T> {
     }
     if (_cachedValueFuture == null) {
       _cachedValueFuture = callback();
-      await _cachedValueFuture;
-      _startStaleTimer();
+      try {
+        await _cachedValueFuture;
+      } finally {
+        _startStaleTimer();
+      }
     }
     return _cachedValueFuture!;
   }

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -158,4 +158,20 @@ void main() {
     }));
     expect(cache.fetchStream(call).toList(), completion(['1', '2', '3']));
   });
+
+  test('should invalidate even if the future throws an exception', () async {
+    cache = AsyncCache.ephemeral();
+
+    Future<String> throwingCall() async => throw Exception();
+    try {
+      await cache.fetch(throwingCall);
+    } catch (exception) {
+      expect(exception, isException);
+    }
+    // To let the timer invalidate the cache
+    await Future.delayed(Duration.zero);
+
+    Future<String> call() async => 'Completed';
+    expect(await cache.fetch(call), 'Completed', reason: 'Cache invalidates');
+  });
 }

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -163,13 +163,9 @@ void main() {
     cache = AsyncCache.ephemeral();
 
     Future<String> throwingCall() async => throw Exception();
-    try {
-      await cache.fetch(throwingCall);
-    } catch (exception) {
-      expect(exception, isException);
-    }
+    await expectLater(cache.fetch(throwingCall), throwsA(isException));
     // To let the timer invalidate the cache
-    await Future.delayed(Duration.zero);
+    await Future.delayed(Duration(milliseconds: 5));
 
     Future<String> call() async => 'Completed';
     expect(await cache.fetch(call), 'Completed', reason: 'Cache invalidates');


### PR DESCRIPTION
When the callback throws an exception, the startStaleTime was not called, so the cache was not refreshed. Because of this, future calls to this cache always returned with the exception.
This pull request solve this issue, by wrapping the `await future` call in a try/finally block.