### PR TITLE
Update to published package versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,3 @@ dev_dependencies:
   stack_trace: ^1.10.0-nullsafety
   test: ^1.16.0-nullsafety
   pedantic: ^1.10.0-nullsafety
-
-dependency_overrides:
-  fake_async:
-    git: git://github.com/dart-lang/fake_async.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,72 +11,12 @@ environment:
 dependencies:
   collection: '>=1.15.0-nullsafety <1.15.0'
 
-dev_dependencies:	
-  fake_async: ^1.0.0	
-  stack_trace: ^1.0.0	
-  test: ^1.0.0	
-  pedantic: ^1.0.0
+dev_dependencies:
+  fake_async: ^1.1.0-nullsafety
+  stack_trace: ^1.10.0-nullsafety
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
 
 dependency_overrides:
-  # Dev dep overrides
-  clock:
-    git:
-      url: git://github.com/dart-lang/clock.git
-      ref: null_safety
   fake_async:
-    git:	
-      url: git://github.com/dart-lang/fake_async.git	
-      ref: null_safety
-  # Normal test dep overrides
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+    git: git://github.com/dart-lang/fake_async.git


### PR DESCRIPTION
- Remove most dependency overrides. Retain `fake_async` which has not
  been published with a null safe version.
- Update `dev_dependencies` to reference the min null safe versions.
- Remove trailing whitespace.