### PR TITLE
Remove unused dart:async import.

### DIFF
--- a/lib/src/result/future.dart
+++ b/lib/src/result/future.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import '../delegate/future.dart';
 import 'result.dart';
 


### PR DESCRIPTION
Since this version doesn't support Dart 2.0, this import is not
necessary.