### PR TITLE
Resolve null safety migration TODOS

### DIFF
--- a/lib/src/result/error.dart
+++ b/lib/src/result/error.dart
@@ -25,8 +25,7 @@ class ErrorResult implements Result<Never> {
   ErrorResult get asError => this;
 
   ErrorResult(this.error, [StackTrace? stackTrace])
-      // TODO: Use AsyncError.defaultStackTrace(error) once available
-      : stackTrace = stackTrace ?? StackTrace.fromString('');
+      : stackTrace = stackTrace ?? AsyncError.defaultStackTrace(error);
 
   @override
   void complete(Completer completer) {

--- a/lib/src/stream_sink_transformer/handler_transformer.dart
+++ b/lib/src/stream_sink_transformer/handler_transformer.dart
@@ -11,11 +11,7 @@ import '../delegate/stream_sink.dart';
 typedef HandleData<S, T> = void Function(S data, EventSink<T> sink);
 
 /// The type of the callback for handling error events.
-//
-// TODO: Update to take a non-nullable StackTrace once that change lands in
-// the sdk.
-typedef HandleError<T> = void Function(
-    Object error, StackTrace stackTrace, EventSink<T> sink);
+typedef HandleError<T> = void Function(Object error, StackTrace, EventSink<T>);
 
 /// The type of the callback for handling done events.
 typedef HandleDone<T> = void Function(EventSink<T> sink);


### PR DESCRIPTION
- Switch from `StackTrace.fromString` to `AsyncError.defaultStackTrace`.
- Remove a TODO about non-nullable `StackTrace`, by the time we merged
  null safety the type was already non-nullable and the TODO was stale.

Style tweak - remove the argument names from a Function type that are
redundant against their type names.