### PR TITLE
Avoid a `late final` field without initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.0-nullsafety.2-dev
+
+* Remove the unusable setter `CancelableOperation.operation=`. This was
+  mistakenly added to the public API but could never be called.
+
 ## 2.5.0-nullsafety.1
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -143,7 +143,7 @@ class CancelableOperation<T> {
 /// A completer for a [CancelableOperation].
 class CancelableCompleter<T> {
   /// The completer for the wrapped future.
-  final Completer<T> _inner;
+  final _inner = Completer<T>();
 
   /// The callback to call if the future is canceled.
   final FutureOrCallback? _onCancel;
@@ -156,14 +156,10 @@ class CancelableCompleter<T> {
   ///
   /// [onCancel] will be called synchronously when the operation is canceled.
   /// It's guaranteed to only be called once.
-  CancelableCompleter({FutureOr Function()? onCancel})
-      : _onCancel = onCancel,
-        _inner = Completer<T>() {
-    operation = CancelableOperation<T>._(this);
-  }
+  CancelableCompleter({FutureOr Function()? onCancel}) : _onCancel = onCancel;
 
   /// The operation controlled by this completer.
-  late final CancelableOperation<T> operation;
+  late final operation = CancelableOperation<T>._(this);
 
   /// Whether the completer has completed.
   bool get isCompleted => _isCompleted;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.5.0-nullsafety.1
+version: 2.5.0-nullsafety.2-dev
 
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async


### PR DESCRIPTION
This had been set in the constructor because it needs to reference
`this`. A new capability with `late final` files is to allow an
initializer expression referencing `this`. This approach also avoid
introducing a setter to the public API. The behavior difference is that
the `CancelableOperation` wont be instantiated until it is read, but
this is fine because `CancelableOperation` does not have any side
effects during initialization and it's only field is the
`CancelableCompleter`. Technically it's statically breaking to remove
the setter, but since it could never be called at runtime this is safe
to do.

Also initialize the `_inner` field where it is defined rather than in an
initializer list since there are not multiple constructors that would
assign different values.