### PR TITLE
Allow 2.12.0 dev SDK versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.5.0-nullsafety.2-dev
+## 2.5.0-nullsafety.2
 
 * Remove the unusable setter `CancelableOperation.operation=`. This was
   mistakenly added to the public API but could never be called.
+* Allow 2.12.0 dev SDK versions.
 
 ## 2.5.0-nullsafety.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,78 +1,18 @@
 name: async
-version: 2.5.0-nullsafety.2-dev
+version: 2.5.0-nullsafety.2
 
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.10.0-0 <2.12.0'
 
 dependencies:
   collection: '>=1.15.0-nullsafety <1.15.0'
 
-dev_dependencies:	
-  fake_async: ^1.0.0	
-  stack_trace: ^1.0.0	
-  test: ^1.0.0	
-  pedantic: ^1.0.0
-
-dependency_overrides:
-  # Dev dep overrides
-  clock:
-    git: git://github.com/dart-lang/clock.git
-  fake_async:
-    git: git://github.com/dart-lang/fake_async.git
-  # Normal test dep overrides
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+dev_dependencies:
+  fake_async: ^1.2.0-nullsafety
+  stack_trace: ^1.10.0-nullsafety
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
Drop dependency overrides and update deps to `-nullsafety` versions.