### PR TITLE
Migrate to runZonedGuarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.5.0-nullsafety.3-dev
+
 ## 2.5.0-nullsafety.2
 
 * Remove the unusable setter `CancelableOperation.operation=`. This was

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.5.0-nullsafety.2
+version: 2.5.0-nullsafety.3-dev
 
 description: Utility functions and classes related to the 'dart:async' library.
 homepage: https://www.github.com/dart-lang/async

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -19,13 +19,13 @@ typedef OptionalArgAction = void Function([dynamic a, dynamic b]);
 OptionalArgAction unreachable(String name) =>
     ([a, b]) => fail('Unreachable: $name');
 
-// TODO(nweiz): Use the version of this in test when test#418 is fixed.
 /// A matcher that runs a callback in its own zone and asserts that that zone
 /// emits an error that matches [matcher].
 Matcher throwsZoned(matcher) => predicate((void Function() callback) {
       var firstError = true;
-      runZoned(callback,
-          onError: expectAsync2((Object error, StackTrace stackTrace) {
+      runZonedGuarded(
+          callback,
+          expectAsync2((error, stackTrace) {
             if (firstError) {
               expect(error, matcher);
               firstError = false;


### PR DESCRIPTION
The `onError` argument to `runZoned` is deprecated. Switch to the
supported `runZonedGuarded`.

Remove argument types on the function literal since thy can now be
inferred. `runZonedGuarded` has a specific function type argument,
whereas `onError` was typed as `Function` which did not allow inference
on argument types.