### PR TITLE
Use the name that matches no library directive

### DIFF
--- a/lib/async.dart
+++ b/lib/async.dart
@@ -5,7 +5,7 @@
 /// Utilities that expand on the asynchronous features of the `dart:async` library.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=r0tHiCjW2w0}
-library pkg.async;
+library async;
 
 export 'src/async_cache.dart';
 export 'src/async_memoizer.dart';


### PR DESCRIPTION
Fixes #156

The readme, and likely other documentation around the web, has links to
the dartdoc site using the library name "async", which is what the
library would be named in the docs if we omitted the `library` directive
entirely. It is easier to restore the old paths by naming the
library identically than to update all the links.