### PR TITLE
Add doc comment on Stream.slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.7.0
 
 * Add a `Stream.slices()` extension method.
-
 * Fix a bug where `CancelableOperation.then` may invoke the `onValue` callback,
   even if it had been canceled before `CancelableOperation.value` completes.
 * Fix a bug in `CancelableOperation.isComplete` where it may appear to be

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -6,6 +6,17 @@ import 'dart:async';
 
 /// Utility extensions on [Stream].
 extension StreamExtensions<T> on Stream<T> {
+
+  /// Creates a stream whose elements are contiguous slices of [this].
+  ///
+  /// Each slice is [length] elements long, except for the last one which may be
+  /// shorter if [this] emits too few elements. Each slice begins after the
+  /// last one ends.
+  ///
+  /// For example, `Stream.fromIterable([1, 2, 3, 4, 5]).slices(2)` emits `([1,
+  /// 2], [3, 4], [5])`.
+  ///
+  /// Errors are forwarded to the result stream.
   Stream<List<T>> slices(int length) {
     if (length < 1) throw RangeError.range(length, 1, null, 'length');
 

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -6,17 +6,18 @@ import 'dart:async';
 
 /// Utility extensions on [Stream].
 extension StreamExtensions<T> on Stream<T> {
-
   /// Creates a stream whose elements are contiguous slices of [this].
   ///
   /// Each slice is [length] elements long, except for the last one which may be
   /// shorter if [this] emits too few elements. Each slice begins after the
   /// last one ends.
   ///
-  /// For example, `Stream.fromIterable([1, 2, 3, 4, 5]).slices(2)` emits `([1,
-  /// 2], [3, 4], [5])`.
+  /// For example, `Stream.fromIterable([1, 2, 3, 4, 5]).slices(2)` emits
+  /// `([1, 2], [3, 4], [5])`.
   ///
-  /// Errors are forwarded to the result stream.
+  /// Errors are forwarded to the result stream immediately when they occur,
+  /// even if previous data events have not been emitted because the next slice
+  /// is not complete yet.
   Stream<List<T>> slices(int length) {
     if (length < 1) throw RangeError.range(length, 1, null, 'length');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  meta: ^1.1.7
   collection: ^1.15.0
+  meta: ^1.1.7
 
 dev_dependencies:
-  fake_async: ^1.2.0-nullsafety
-  stack_trace: ^1.10.0-nullsafety
-  test: ^1.16.0-nullsafety
-  pedantic: ^1.10.0-nullsafety
+  fake_async: ^1.2.0
+  pedantic: ^1.10.0
+  stack_trace: ^1.10.0
+  test: ^1.16.0


### PR DESCRIPTION
Based on the doc comment on the unmerged Iterable.slices from
https://github.com/dart-lang/collection/pull/191

Drop extra newline in changelog, sort deps, and drop `-nullsafety` from
constraints.