### PR TITLE
Fix broadcast StreamGroup ignores streams added after StreamGroup is canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   easier to implement custom sinks.
 * Improve performance for `ChunkedStreamReader` by creating fewer internal
   sublists and specializing to create views for `Uint8List` chunks.
+* Don't ignore broadcast streams added to a `StreamGroup` that doesn't have an
+  active listener but previously had listeners and contains a single
+  subscription inner stream.
 
 ## 2.7.0
 

--- a/lib/src/stream_group.dart
+++ b/lib/src/stream_group.dart
@@ -192,7 +192,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
       // If this is a broadcast group and this isn't the first time it's been
       // listened to, there may still be some subscriptions to
       // single-subscription streams.
-      if (entry.value != null) return;
+      if (entry.value != null) continue;
 
       var stream = entry.key;
       try {

--- a/test/stream_group_test.dart
+++ b/test/stream_group_test.dart
@@ -417,6 +417,24 @@ void main() {
       expect(controller.hasListener, isTrue);
     });
 
+    test(
+        'listens on streams that follow single-subscription streams when '
+        'relistening after a cancel', () async {
+      var controller1 = StreamController<String>();
+      streamGroup.add(controller1.stream);
+      streamGroup.stream.listen(null).cancel();
+
+      var controller2 = StreamController<String>();
+      streamGroup.add(controller2.stream);
+
+      var emitted = <String>[];
+      streamGroup.stream.listen(emitted.add);
+      controller1.add('one');
+      controller2.add('two');
+      await flushMicrotasks();
+      expect(emitted, ['one', 'two']);
+    });
+
     test('never cancels single-subscription streams', () async {
       var subscription = streamGroup.stream.listen(null);
 


### PR DESCRIPTION
Fix #183 