### PR TITLE
Use BytesBuilder for collectBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.7.1-dev
+
 ## 2.7.0
 
 * Add a `Stream.slices()` extension method.

--- a/lib/src/byte_collector.dart
+++ b/lib/src/byte_collector.dart
@@ -42,30 +42,13 @@ CancelableOperation<Uint8List> collectBytesCancelable(
 /// so it can cancel the operation.
 T _collectBytes<T>(Stream<List<int>> source,
     T Function(StreamSubscription<List<int>>, Future<Uint8List>) result) {
-  var byteLists = <List<int>>[];
-  var length = 0;
+  var bytes = BytesBuilder();
   var completer = Completer<Uint8List>.sync();
-  var subscription = source.listen(
-      (bytes) {
-        byteLists.add(bytes);
-        length += bytes.length;
-      },
+  var subscription = source.listen(bytes.add,
       onError: completer.completeError,
       onDone: () {
-        completer.complete(_collect(length, byteLists));
+        completer.complete(bytes.takeBytes());
       },
       cancelOnError: true);
   return result(subscription, completer.future);
-}
-
-// Join a lists of bytes with a known total length into a single [Uint8List].
-Uint8List _collect(int length, List<List<int>> byteLists) {
-  var result = Uint8List(length);
-  var i = 0;
-  for (var byteList in byteLists) {
-    var end = i + byteList.length;
-    result.setRange(i, end, byteList);
-    i = end;
-  }
-  return result;
 }

--- a/lib/src/byte_collector.dart
+++ b/lib/src/byte_collector.dart
@@ -44,11 +44,9 @@ T _collectBytes<T>(Stream<List<int>> source,
     T Function(StreamSubscription<List<int>>, Future<Uint8List>) result) {
   var bytes = BytesBuilder();
   var completer = Completer<Uint8List>.sync();
-  var subscription = source.listen(bytes.add,
-      onError: completer.completeError,
-      onDone: () {
-        completer.complete(bytes.takeBytes());
-      },
-      cancelOnError: true);
+  var subscription =
+      source.listen(bytes.add, onError: completer.completeError, onDone: () {
+    completer.complete(bytes.takeBytes());
+  }, cancelOnError: true);
   return result(subscription, completer.future);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.7.0
+version: 2.7.1-dev
 
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async


### PR DESCRIPTION
When this utility was first written `BytesBuilder` was only importable
from `dart:io`. Now that it may be imported from the cross platform
`dart:typed_data` it can be used in `package:async`.