### PR TITLE
Avoid copying with BytesBuilder

### DIFF
--- a/lib/src/byte_collector.dart
+++ b/lib/src/byte_collector.dart
@@ -42,11 +42,11 @@ CancelableOperation<Uint8List> collectBytesCancelable(
 /// so it can cancel the operation.
 T _collectBytes<T>(Stream<List<int>> source,
     T Function(StreamSubscription<List<int>>, Future<Uint8List>) result) {
-  var bytes = BytesBuilder();
+  var bytes = BytesBuilder(copy: false);
   var completer = Completer<Uint8List>.sync();
   var subscription =
       source.listen(bytes.add, onError: completer.completeError, onDone: () {
-    completer.complete(bytes.toBytes());
+    completer.complete(bytes.takeBytes());
   }, cancelOnError: true);
   return result(subscription, completer.future);
 }

--- a/lib/src/byte_collector.dart
+++ b/lib/src/byte_collector.dart
@@ -46,7 +46,7 @@ T _collectBytes<T>(Stream<List<int>> source,
   var completer = Completer<Uint8List>.sync();
   var subscription =
       source.listen(bytes.add, onError: completer.completeError, onDone: () {
-    completer.complete(bytes.takeBytes());
+    completer.complete(bytes.toBytes());
   }, cancelOnError: true);
   return result(subscription, completer.future);
 }


### PR DESCRIPTION
The previous implementation of `collectBytes` would return a `Uint8List`
where the `lengthInBytes` and `buffer.lengthInBytes` matched. This
property isn't an intended guarantee, however since some callers may
rely on it for correct behavior it is safer to retain it. Use `copy: false`
so that the buffer used in `takeBytes` has the same length as the data.