### PR TITLE
Prepare to publish (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
+## 2.8.1
+
+* Don't ignore broadcast streams added to a `StreamGroup` that doesn't have an
+  active listener but previously had listeners and contains a single
+  subscription inner stream.
+
 ## 2.8.0
 
 * Add `EventSinkBase`, `StreamSinkBase`, and `IOSinkBase` classes to make it
   easier to implement custom sinks.
 * Improve performance for `ChunkedStreamReader` by creating fewer internal
   sublists and specializing to create views for `Uint8List` chunks.
-* Don't ignore broadcast streams added to a `StreamGroup` that doesn't have an
-  active listener but previously had listeners and contains a single
-  subscription inner stream.
 
 ## 2.7.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.8.0
+version: 2.8.1
 
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async


### PR DESCRIPTION
I made the previous publish at a commit too early. Move the changelog
for the `StreamGroup` bug fix to a new version and prepare to publish.