### PR TITLE
Stop depending on pkg:charcode and pkg:pedantic.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,7 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  strong-mode:
+    implicit-casts: false
   errors:
     todo: ignore

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,15 +1,5 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
   errors:
     todo: ignore
-    # Lint provided by pkg:pedantic – should fix this!
-    unawaited_futures: ignore
-  enable-experiment:
-    - non-nullable
-
-linter:
-  rules:
-    - prefer_typing_uninitialized_variables

--- a/lib/src/chunked_stream_reader.dart
+++ b/lib/src/chunked_stream_reader.dart
@@ -118,7 +118,7 @@ class ChunkedStreamReader<T> {
     }
     _reading = true;
 
-    final substream = () async* {
+    Stream<List<T>> substream() async* {
       // While we have data to read
       while (size > 0) {
         // Read something into the buffer, if buffer has been consumed.
@@ -158,7 +158,7 @@ class ChunkedStreamReader<T> {
           yield output;
         }
       }
-    };
+    }
 
     final c = StreamController<List<T>>();
     c.onListen = () => c.addStream(substream()).whenComplete(c.close);

--- a/lib/src/stream_group.dart
+++ b/lib/src/stream_group.dart
@@ -74,7 +74,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   Stream<void> get onIdle =>
       (_onIdleController ??= StreamController.broadcast()).stream;
 
-  StreamController<Null>? _onIdleController;
+  StreamController<void>? _onIdleController;
 
   /// Streams that have been added to the group, and their subscriptions if they
   /// have been subscribed to.
@@ -169,7 +169,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   /// [StreamSubscription.cancel]'s return value. Otherwise, it returns `null`.
   Future? remove(Stream<T> stream) {
     var subscription = _subscriptions.remove(stream);
-    var future = subscription == null ? null : subscription.cancel();
+    var future = subscription?.cancel();
 
     if (_subscriptions.isEmpty) {
       _onIdleController?.add(null);

--- a/lib/src/stream_sink_transformer.dart
+++ b/lib/src/stream_sink_transformer.dart
@@ -53,7 +53,7 @@ abstract class StreamSinkTransformer<S, T> {
   /// This means that calls to [StreamSink.add] on the returned sink may throw a
   /// [TypeError] if the argument type doesn't match the reified type of the
   /// sink.
-  @deprecated
+  @Deprecated("Will be removed in future version")
   // TODO remove TypeSafeStreamSinkTransformer
   static StreamSinkTransformer<S, T> typed<S, T>(
           StreamSinkTransformer transformer) =>

--- a/lib/src/stream_sink_transformer/reject_errors.dart
+++ b/lib/src/stream_sink_transformer/reject_errors.dart
@@ -113,8 +113,7 @@ class RejectErrorsSink<T> implements StreamSink<T> {
     _closed = true;
 
     if (!_canceled) {
-      _inner.close();
-      _doneCompleter.complete();
+      _doneCompleter.complete(_inner.close());
     }
     return done;
   }

--- a/lib/src/stream_sink_transformer/reject_errors.dart
+++ b/lib/src/stream_sink_transformer/reject_errors.dart
@@ -113,6 +113,7 @@ class RejectErrorsSink<T> implements StreamSink<T> {
     _closed = true;
 
     if (!_canceled) {
+      // ignore: void_checks
       _doneCompleter.complete(_inner.close());
     }
     return done;

--- a/lib/src/stream_sink_transformer/reject_errors.dart
+++ b/lib/src/stream_sink_transformer/reject_errors.dart
@@ -112,7 +112,10 @@ class RejectErrorsSink<T> implements StreamSink<T> {
     if (_closed) return done;
     _closed = true;
 
-    if (!_canceled) _doneCompleter.complete(_inner.close());
+    if (!_canceled) {
+      _inner.close();
+      _doneCompleter.complete();
+    }
     return done;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.8.2
+version: 2.8.3
 
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
@@ -12,8 +12,7 @@ dependencies:
   meta: ^1.1.7
 
 dev_dependencies:
-  charcode: ^1.3.0
   fake_async: ^1.2.0
-  pedantic: ^1.10.0
+  lints: ^1.0.0
   stack_trace: ^1.10.0
   test: ^1.16.0

--- a/test/io_sink_impl.dart
+++ b/test/io_sink_impl.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@deprecated
+@Deprecated("Tests deprecated functionality")
 library io_sink_impl;
 
 import 'dart:io';

--- a/test/result/result_captureAll_test.dart
+++ b/test/result/result_captureAll_test.dart
@@ -20,7 +20,7 @@ Result err(n) => ErrorResult('$n', someStack);
 Iterable<Future<int>> futures(int count,
     {bool Function(int index)? throwWhen}) sync* {
   for (var i = 0; i < count; i++) {
-    if (throwWhen != null && throwWhen(i)) {
+  if (throwWhen != null && throwWhen(i)) {
       yield Future<int>.error('$i', someStack);
     } else {
       yield Future<int>.value(i);

--- a/test/result/result_captureAll_test.dart
+++ b/test/result/result_captureAll_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: file_names
+
 import 'dart:async';
 import 'dart:math' show Random;
 

--- a/test/result/result_captureAll_test.dart
+++ b/test/result/result_captureAll_test.dart
@@ -20,7 +20,7 @@ Result err(n) => ErrorResult('$n', someStack);
 Iterable<Future<int>> futures(int count,
     {bool Function(int index)? throwWhen}) sync* {
   for (var i = 0; i < count; i++) {
-  if (throwWhen != null && throwWhen(i)) {
+    if (throwWhen != null && throwWhen(i)) {
       yield Future<int>.error('$i', someStack);
     } else {
       yield Future<int>.value(i);

--- a/test/result/result_flattenAll_test.dart
+++ b/test/result/result_flattenAll_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: file_names
+
 import 'package:async/async.dart';
 import 'package:test/test.dart';
 

--- a/test/sink_base_test.dart
+++ b/test/sink_base_test.dart
@@ -8,10 +8,11 @@ library sink_base_test;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:charcode/charcode.dart';
 import 'package:test/test.dart';
 
 import 'package:async/async.dart';
+
+const int letterA = 0x41;
 
 void main() {
   // We don't explicitly test [EventSinkBase] because it shares all the relevant
@@ -54,7 +55,6 @@ void main() {
       var controller = StreamController<int>();
       var addStreamCompleted = false;
       sink.addStream(controller.stream).then((_) => addStreamCompleted = true);
-      ;
 
       await pumpEventQueue();
       expect(addStreamCompleted, isFalse);
@@ -277,7 +277,7 @@ void main() {
         var sink = _IOSink(onAdd: expectAsync1((data) {
           expect(data, equals(utf8.encode('A')));
         }));
-        sink.writeCharCode($A);
+        sink.writeCharCode(letterA);
       });
 
       test('respects the encoding', () async {
@@ -292,7 +292,7 @@ void main() {
       test('throws if the sink is closed', () async {
         var sink = _IOSink(onAdd: expectAsync1((_) {}, count: 0));
         expect(sink.close(), completes);
-        expect(() => sink.writeCharCode($A), throwsStateError);
+        expect(() => sink.writeCharCode(letterA), throwsStateError);
       });
     });
 

--- a/test/sink_base_test.dart
+++ b/test/sink_base_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@deprecated
+@Deprecated("Tests deprecated functionality")
 library sink_base_test;
 
 import 'dart:async';

--- a/test/stream_queue_test.dart
+++ b/test/stream_queue_test.dart
@@ -543,7 +543,7 @@ void main() {
       test('returns the result of closing the underlying subscription',
           () async {
         var controller =
-            StreamController<int>(onCancel: () => Future.value(42));
+            StreamController<int>(onCancel: () => Future<int>.value(42));
         var events = StreamQueue<int>(controller.stream);
         expect(await events.cancel(immediate: true), 42);
       });

--- a/test/subscription_transformer_test.dart
+++ b/test/subscription_transformer_test.dart
@@ -13,8 +13,9 @@ void main() {
   group('with no callbacks', () {
     test('forwards cancellation', () async {
       var isCanceled = false;
-      var cancelCompleter = Completer();
-      var controller = StreamController(onCancel: expectAsync0(() {
+      var cancelCompleter = Completer<void>();
+      var controller =
+          StreamController(onCancel: expectAsync0<Future<void>>(() {
         isCanceled = true;
         return cancelCompleter.future;
       }));


### PR DESCRIPTION
Use pkg:lints instead of pkg:pedantic (and update code as necessary).
Use a local constant instead of depending on pkg:charcode.