### PR TITLE
Deprecate sink_base classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.2
+
+* Deprecate `EventSinkBase`, `StreamSinkBase`, `IOSinkBase`.
+
 ## 2.8.1
 
 * Don't ignore broadcast streams added to a `StreamGroup` that doesn't have an

--- a/lib/src/sink_base.dart
+++ b/lib/src/sink_base.dart
@@ -14,6 +14,7 @@ import 'async_memoizer.dart';
 ///
 /// This takes care of ensuring that events can't be added after [close] is
 /// called.
+@Deprecated('Will be removed in the next major release')
 abstract class EventSinkBase<T> implements EventSink<T> {
   /// Whether [close] has been called and no more events may be written.
   bool get _closed => _closeMemo.hasRun;
@@ -61,6 +62,7 @@ abstract class EventSinkBase<T> implements EventSink<T> {
 ///
 /// This takes care of ensuring that events can't be added after [close] is
 /// called or during a call to [onStream].
+@Deprecated('Will be removed in the next major release')
 abstract class StreamSinkBase<T> extends EventSinkBase<T>
     implements StreamSink<T> {
   /// Whether a call to [addStream] is ongoing.
@@ -104,6 +106,7 @@ abstract class StreamSinkBase<T> extends EventSinkBase<T>
 ///
 /// This takes care of ensuring that events can't be added after [close] is
 /// called or during a call to [onStream].
+@Deprecated('Will be removed in the next major release')
 abstract class IOSinkBase extends StreamSinkBase<List<int>> {
   /// See [IOSink.encoding] from `dart:io`.
   Encoding encoding;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.8.1
+version: 2.8.2
 
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async

--- a/test/io_sink_impl.dart
+++ b/test/io_sink_impl.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@deprecated
+library io_sink_impl;
+
 import 'dart:io';
 
 import 'package:async/async.dart';

--- a/test/sink_base_test.dart
+++ b/test/sink_base_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@deprecated
+library sink_base_test;
+
 import 'dart:async';
 import 'dart:convert';
 


### PR DESCRIPTION
The approach was not considered a good fit for the package API,
and we'll remove the classes and consider another approach, if one is needed.