### PR TITLE
Let `firstOrNull` extension method wait for `cancel` to complete.

### DIFF
--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -43,19 +43,15 @@ extension StreamExtensions<T> on Stream<T> {
   /// completed with `null`.
   Future<T?> get firstOrNull {
     var completer = Completer<T?>.sync();
-    final subscription = listen(null);
-    subscription
-      ..onData((event) {
-        subscription.cancel();
+    final subscription = listen(null,
+        onError: completer.completeError,
+        onDone: completer.complete,
+        cancelOnError: true);
+    subscription.onData((event) {
+      subscription.cancel().whenComplete(() {
         completer.complete(event);
-      })
-      ..onError((Object error, StackTrace stackTrace) {
-        subscription.cancel();
-        completer.completeError(error, stackTrace);
-      })
-      ..onDone(() {
-        completer.complete(null);
       });
+    });
     return completer.future;
   }
 }


### PR DESCRIPTION
I missed that we didn't wait for the `subscription.cancel` to complete before reporting the event, which is always good style for stream subscriptions.
With `cancelOnError:true`, the `onError` event won't happen before the auto-`cancel` has completed.