### PR TITLE
Fix an ArgumentError constructor call

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.14.1, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -69,7 +69,7 @@ class CancelableOperation<T> {
       Iterable<CancelableOperation<T>> operations) {
     operations = operations.toList();
     if (operations.isEmpty) {
-      throw ArgumentError.value("May not be empty", "operations");
+      throw ArgumentError("May not be empty", "operations");
     }
 
     var done = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
The arguments that were passed match the intention of the
`ArgumentError` constructor, while the `ArgumentError.value` constructor
reverses the message and argument name, and includes the argument value.
Including the value is not useful in this case since it is always `[]`
and in most cases won't be the exact instance that was passed because of
the `.toList()` call which would usually construct a copy.

Bump the min SDK constraint to `2.14` which is the first release
allowing the `name` argument to the `ArgumentError` constructor.