### PR TITLE
update some StreamGroup apis to Future<void> from Future<dynamic>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 2.9.0
+## 2.9.0-dev
 
 * Add `StreamExtensions.firstOrNull`.
 
 * Add a `CancelableOperation.fromSubscription()` static factory.
 
 * Add a `CancelableOperation.race()` static method.
+
+* Update `StreamGroup` methods that return a `Future<dynamic>` today to return
+  a `Future<void>` instead.
 
 ## 2.8.2
 

--- a/lib/src/stream_group.dart
+++ b/lib/src/stream_group.dart
@@ -137,7 +137,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   ///
   /// Throws a [StateError] if this group is closed.
   @override
-  Future? add(Stream<T> stream) {
+  Future<void>? add(Stream<T> stream) {
     if (_closed) {
       throw StateError("Can't add a Stream to a closed StreamGroup.");
     }
@@ -167,7 +167,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   ///
   /// If [stream]'s subscription is canceled, this returns
   /// [StreamSubscription.cancel]'s return value. Otherwise, it returns `null`.
-  Future? remove(Stream<T> stream) {
+  Future<void>? remove(Stream<T> stream) {
     var subscription = _subscriptions.remove(stream);
     var future = subscription?.cancel();
 
@@ -226,7 +226,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   /// A callback called when [stream] is canceled.
   ///
   /// This is only called for single-subscription groups.
-  Future? _onCancel() {
+  Future<void>? _onCancel() {
     _state = _StreamGroupState.canceled;
 
     var futures = _subscriptions.entries
@@ -287,7 +287,7 @@ class StreamGroup<T> implements Sink<Stream<T>> {
   ///
   /// Returns a [Future] that completes once [stream] has actually been closed.
   @override
-  Future close() {
+  Future<void> close() {
     if (_closed) return _controller.done;
 
     _closed = true;


### PR DESCRIPTION
This is probably technically breaking for some cases - but it doesn't look to be breaking for anything at all internally, so I think in practice it is not breaking. Finishing up a global presubmit now with all the changes (but already did one with a subset).

WDYT?