### PR TITLE
Update `CancelableOperation` test to not assume completion happens synchronously.

### DIFF
--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -421,12 +421,12 @@ void main() {
     });
 
     group('original operation canceled', () {
-      test('onCancel not set', () {
+      test('onCancel not set', () async {
         onCancel = null;
 
         final operation = runThen();
 
-        expect(originalCompleter.operation.cancel(), completes);
+        await expectLater(originalCompleter.operation.cancel(), completes);
         expect(operation.isCanceled, true);
       });
 
@@ -460,8 +460,10 @@ void main() {
         var operation = runThen();
         var workCompleter = Completer<int>();
         originalCompleter.complete(workCompleter.future);
-        originalCompleter.operation.cancel();
+        var cancelation = originalCompleter.operation.cancel();
+        expect(originalCompleter.isCanceled, true);
         workCompleter.complete(0);
+        await cancelation;
         expect(operation.isCanceled, true);
         await workCompleter.future;
       });


### PR DESCRIPTION
A bug in `Completer.complete` could allow the completion to happen synchronously, even on a non-synchronous completer.
That is being fixed in the SDK.

That affects `AsyncMemoizer`, which uses a pattern which could trigger the bug.
The `CancelableOperation`  completer uses such a memoizer and that would cause a `cancel` to trigger `.then` listeners synchronusly.

With that no longer being the case, two tests needed to insert delays to wait for the cancellation to be propagated to the listner.