### PR TITLE
Revert change of visible behavior in `CancelableOperation`.

### DIFF
--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -495,6 +495,48 @@ void main() {
 
         expect(originalCompleter.isCanceled, false);
       });
+
+      test('onValue callback not called after cancel', () async {
+        var called = false;
+        onValue = expectAsync1((_) {
+          called = true;
+          fail("onValue unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        originalCompleter.complete(0);
+        await flushMicrotasks();
+        expect(called, false);
+      });
+
+      test('onError callback not called after cancel', () async {
+        var called = false;
+        onError = expectAsync2((_, __) {
+          called = true;
+          fail("onError unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        originalCompleter.completeError("Error", StackTrace.empty);
+        await flushMicrotasks();
+        expect(called, false);
+      });
+
+      test('onCancel callback not called after cancel', () async {
+        var called = false;
+        onCancel = expectAsync0(() {
+          called = true;
+          fail("onCancel unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        await originalCompleter.operation.cancel();
+        await flushMicrotasks();
+        expect(called, false);
+      });
     });
   });
 

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -501,7 +501,6 @@ void main() {
         onValue = expectAsync1((_) {
           called = true;
           fail("onValue unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();
@@ -515,7 +514,6 @@ void main() {
         onError = expectAsync2((_, __) {
           called = true;
           fail("onError unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();
@@ -529,7 +527,6 @@ void main() {
         onCancel = expectAsync0(() {
           called = true;
           fail("onCancel unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();


### PR DESCRIPTION
A prior change made it so that a `.then` on a `CancelableOperation`
would call the `onValue`/`onError` callback even if the
returned operation was cancelled beteen the time of the `then`
and the time the original operation completed.
The result would not show up in the cancelled operation,
but the callbacks would run.

This change blocks calling the callbacks if the returned operation
has been cancelled.

Q.v. #204