### PR TITLE
Deprecate `AsyncCache.fetchStream`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Update `StreamGroup` methods that return a `Future<dynamic>` today to return
   a `Future<void>` instead.
 
+* Deprecated `AsyncCache.fetchStream`.
+
 ## 2.8.2
 
 * Deprecate `EventSinkBase`, `StreamSinkBase`, `IOSinkBase`.

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -74,6 +74,7 @@ class AsyncCache<T> {
   /// If [fetchStream] has been called recently enough, returns a copy of its
   /// previous return value. Otherwise, runs [callback] and returns its new
   /// return value.
+  @Deprecated("Feature will be removed")
   Stream<T> fetchStream(Stream<T> Function() callback) {
     if (_cachedValueFuture != null) {
       throw StateError('Previously used to cache via `fetch`');


### PR DESCRIPTION
The `featchStream` feature complicates the `AsyncCache` class, and would be a better fit for a separate class.
The functionality is not great. Since it returns the "same" stream each time the cache is queried (until evaluated), it actually
caches all stream events.
The invalidation is tricky because the timer doesn't start until you *listen* to the stream. In practice, people will usually listen to the stream they fetch.

It also seems that no-one ever used the functionality.
There is no use inside Google, or in [Github](https://github.com/search?q=%22.fetchStream%22+language%3ADart+-filename%3Aasync_cache.dart+-filename%3Aasync_cache_test.dart&type=code), outside of the package's own tests.
