### PR TITLE
Add CancelableOperation.thenOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.10.0-dev
 
+* Add `CancelableOperation.thenOperation` which gives more flexibility to
+  complete the resulting operation.
+
+## 2.9.0
+
 * **Potentially Breaking** The default `propagateCancel` argument to
   `CancelableOperation.then` changed from `false` to `true`. In most usages this
   won't have a meaningful difference in behavior, but in usages where the
@@ -7,9 +12,6 @@
   `CancelableOperation` with multiple listeners where canceling subsequent
   computation using `.then` shouldn't also cancel the original operation, pass
   `propagateCancel: false`.
-
-## 2.9.0
-
 * Add `StreamExtensions.firstOrNull`.
 * Add a `CancelableOperation.fromSubscription()` static factory.
 * Add a `CancelableOperation.race()` static method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.0
+## 2.10.0-dev
 
 * **Potentially Breaking** The default `propagateCancel` argument to
   `CancelableOperation.then` changed from `false` to `true`. In most usages this
@@ -7,6 +7,9 @@
   `CancelableOperation` with multiple listeners where canceling subsequent
   computation using `.then` shouldn't also cancel the original operation, pass
   `propagateCancel: false`.
+
+## 2.9.0
+
 * Add `StreamExtensions.firstOrNull`.
 * Add a `CancelableOperation.fromSubscription()` static factory.
 * Add a `CancelableOperation.race()` static method.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -264,7 +264,8 @@ class CancelableOperation<T> {
                 try {
                   await onError(error, stack, completer);
                 } catch (error2, stack2) {
-                  completer.completeError(error2, stack2);
+                  completer.completeError(
+                      error2, identical(error, error2) ? stack : stack2);
                 }
               });
     _completer._cancelCompleter?.future.whenComplete(onCancel == null

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -154,35 +154,23 @@ class CancelableOperation<T> {
   /// listeners on this operation and canceling the [onValue], [onError], and
   /// [onCancel] callbacks should not cancel the other listeners.
   CancelableOperation<R> then<R>(FutureOr<R> Function(T) onValue,
-      {FutureOr<R> Function(Object, StackTrace)? onError,
-      FutureOr<R> Function()? onCancel,
-      bool propagateCancel = true}) {
-    if (onError != null && onCancel != null) {
-      return thenOperation<R>((value, completer) {
+          {FutureOr<R> Function(Object, StackTrace)? onError,
+          FutureOr<R> Function()? onCancel,
+          bool propagateCancel = true}) =>
+      thenOperation<R>((value, completer) {
         completer.complete(onValue(value));
-      }, onError: (error, stack, completer) {
-        completer.complete(onError(error, stack));
-      }, onCancel: (completer) {
-        completer.complete(onCancel());
-      }, propagateCancel: propagateCancel);
-    } else if (onError != null) {
-      return thenOperation<R>((value, completer) {
-        completer.complete(onValue(value));
-      }, onError: (error, stack, completer) {
-        completer.complete(onError(error, stack));
-      }, propagateCancel: propagateCancel);
-    } else if (onCancel != null) {
-      return thenOperation<R>((value, completer) {
-        completer.complete(onValue(value));
-      }, onCancel: (completer) {
-        completer.complete(onCancel());
-      }, propagateCancel: propagateCancel);
-    } else {
-      return thenOperation<R>((value, completer) {
-        completer.complete(onValue(value));
-      }, propagateCancel: propagateCancel);
-    }
-  }
+      },
+          onError: onError == null
+              ? null
+              : (error, stackTrace, completer) {
+                  completer.complete(onError(error, stackTrace));
+                },
+          onCancel: onCancel == null
+              ? null
+              : (completer) {
+                  completer.complete(onCancel());
+                },
+          propagateCancel: propagateCancel);
 
   /// Creates a new cancelable operation to be completed
   /// when this operation completes or is cancelled.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -133,7 +133,7 @@ class CancelableOperation<T> {
   /// Creates a new cancelable operation to be completed when this operation
   /// completes normally or as an error, or is cancelled.
   ///
-  /// If this operation completes normally the [value] is passed to [onValue]
+  /// If this operation completes normally the value is passed to [onValue]
   /// and the returned operation is completed with the result.
   ///
   /// If this operation completes as an error, and no [onError] callback is
@@ -146,6 +146,11 @@ class CancelableOperation<T> {
   /// the returned operation is canceled.
   /// If this operation is canceled, and an [onCancel] callback is provided,
   /// the returned operation is completed with the result.
+  ///
+  /// At most one of [onValue], [onError], or [onCancel] will be called.
+  /// If any of [onValue], [onError], or [onCancel] throw a synchronous error,
+  /// or return a `Future` that completes as an error, the error will be
+  /// forwarded through the returned operation.
   ///
   /// If the returned operation is canceled before this operation completes or
   /// is canceled, the [onValue], [onError], and [onCancel] callbacks will not
@@ -175,30 +180,7 @@ class CancelableOperation<T> {
   /// Creates a new cancelable operation to be completed when this operation
   /// completes normally or as an error, or is cancelled.
   ///
-  /// If this operation completes normally [onValue] is called with the result
-  /// and the [CancelableCompleter] controlling the returned operation.
-  ///
-  /// If this operation completes as an error, and an [onError] callback is
-  /// provided, it is called with the error, stack trace, and the
-  /// [CancelableCompleter] controlling the returned operation.
-  ///
-  /// If this operation is canceled, and an [onCancel] call is provided, it is
-  /// called with the [CancelableCompleter] controlling the returned operation.
-  ///
-  /// If [onCancel] is not provided, and this operation is canceled, then the
-  /// returned operation is also canceled.
-  ///
-  /// At most one of [onValue], [onError], or [onCancel] will be called.
-  /// If any of [onValue], [onError], or [onCancel] cause any asynchronous
-  /// errors, including through a returned `Future`, they will not be handled or
-  /// forwarded through the returned operation.
-  ///
-  /// If [propagateCancel] is `true` and the returned operation is canceled
-  /// then this operation is canceled. The default is `false`.
-  /// Creates a new cancelable operation to be completed when this operation
-  /// completes normally or as an error, or is cancelled.
-  ///
-  /// If this operation completes normally the [value] is passed to [onValue]
+  /// If this operation completes normally the value is passed to [onValue]
   /// with a [CancelableCompleter] controlling the returned operation.
   ///
   /// If this operation completes as an error, and no [onError] callback is
@@ -213,6 +195,11 @@ class CancelableOperation<T> {
   /// If this operation is canceled, and an [onCancel] callback is provided,
   /// the [onCancel] callback is called with a [CancelableCompleter] controlling
   /// the returned operation.
+  ///
+  /// At most one of [onValue], [onError], or [onCancel] will be called.
+  /// If any of [onValue], [onError], or [onCancel] throw a synchronous error,
+  /// or return a `Future` that completes as an error, the error will be
+  /// forwarded through the returned operation.
   ///
   /// If the returned operation is canceled before this operation completes or
   /// is canceled, the [onValue], [onError], and [onCancel] callbacks will not

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -172,12 +172,8 @@ class CancelableOperation<T> {
                 },
           propagateCancel: propagateCancel);
 
-  /// Creates a new cancelable operation to be completed
-  /// when this operation completes or is cancelled.
-  ///
-  /// The [onValue] and [onError] callbacks behave in the same way as
-  /// for [Future.then], and the result of those callbacks is used to complete
-  /// the returned cancelable operation.
+  /// Creates a new cancelable operation to be completed when this operation
+  /// completes normally or as an error, or is cancelled.
   ///
   /// If this operation completes normally [onValue] is called with the result
   /// and the [CancelableCompleter] controlling the returned operation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.9.0
+version: 2.10.0-dev
 
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -495,6 +495,48 @@ void main() {
 
         expect(originalCompleter.isCanceled, false);
       });
+
+      test('onValue callback not called after cancel', () async {
+        var called = false;
+        onValue = expectAsync1((_) {
+          called = true;
+          fail("onValue unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        originalCompleter.complete(0);
+        await flushMicrotasks();
+        expect(called, false);
+      });
+
+      test('onError callback not called after cancel', () async {
+        var called = false;
+        onError = expectAsync2((_, __) {
+          called = true;
+          fail("onError unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        originalCompleter.completeError("Error", StackTrace.empty);
+        await flushMicrotasks();
+        expect(called, false);
+      });
+
+      test('onCancel callback not called after cancel', () async {
+        var called = false;
+        onCancel = expectAsync0(() {
+          called = true;
+          fail("onCancel unreachable");
+          return "";
+        }, count: 0);
+
+        await runThen().cancel();
+        await originalCompleter.operation.cancel();
+        await flushMicrotasks();
+        expect(called, false);
+      });
     });
   });
 

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -537,6 +537,208 @@ void main() {
     });
   });
 
+  group('thenOperation', () {
+    late void Function(int, CancelableCompleter<String>) onValue;
+    void Function(Object, StackTrace, CancelableCompleter<String>)? onError;
+    void Function(CancelableCompleter<String>)? onCancel;
+    late bool propagateCancel;
+    late CancelableCompleter<int> originalCompleter;
+
+    setUp(() {
+      // Initialize all functions to ones that expect to not be called.
+      onValue = expectAsync2((value, completer) => completer.complete('$value'),
+          count: 0, id: 'onValue');
+      onError = null;
+      onCancel = null;
+      propagateCancel = false;
+      originalCompleter = CancelableCompleter();
+    });
+
+    CancelableOperation<String> runThenOperation() {
+      return originalCompleter.operation
+          .thenOperation(onValue, onError: onError, onCancel: onCancel, propagateCancel:  propagateCancel);
+    }
+
+    group('original operation completes successfully', () {
+      test('onValue completes successfully', () {
+        onValue =
+            expectAsync2((v, c) => c.complete('$v'), count: 1, id: 'onValue');
+
+        expect(runThenOperation().value, completion('1'));
+        originalCompleter.complete(1);
+      });
+
+      test('onValue throws error', () {
+        // expectAsync1 only works with functions that do not throw.
+        onValue = (_, __) => throw 'error';
+
+        expect(runThenOperation().value, throwsA('error'));
+        originalCompleter.complete(1);
+      });
+
+      test('onValue completes as error', () {
+        onValue = expectAsync2(
+            (_, completer) => completer.completeError('error'),
+            count: 1,
+            id: 'onValue');
+
+        expect(runThenOperation().value, throwsA('error'));
+        originalCompleter.complete(1);
+      });
+
+      test('and returned operation is canceled', () async {
+        onValue = expectAsync2((_, __) => throw 'never called', count: 0);
+        runThenOperation().cancel();
+        // onValue should not be called.
+        originalCompleter.complete(1);
+      });
+    });
+
+    group('original operation completes with error', () {
+      test('onError not set', () {
+        onError = null;
+
+        expect(runThenOperation().value, throwsA('error'));
+        originalCompleter.completeError('error');
+      });
+
+      test('onError completes operation', () {
+        onError = expectAsync3((e, s, c) => c.complete('onError caught $e'),
+            count: 1, id: 'onError');
+
+        expect(runThenOperation().value, completion('onError caught error'));
+        originalCompleter.completeError('error');
+      });
+
+      test('onError throws', () {
+        // expectAsync3 does not work with functions that throw.
+        onError = (e, s, c) => throw 'onError caught $e';
+
+        expect(runThenOperation().value, throwsA('onError caught error'));
+        originalCompleter.completeError('error');
+      });
+
+      test('onError completes operation as an error', () {
+        onError = expectAsync3(
+            (e, s, c) => c.completeError('onError caught $e'),
+            count: 1,
+            id: 'onError');
+
+        expect(runThenOperation().value, throwsA('onError caught error'));
+        originalCompleter.completeError('error');
+      });
+
+      test('and returned operation is canceled with propagateCancel = false',
+          () async {
+        onError = expectAsync3((e, s, c) {}, count: 0);
+
+        runThenOperation().cancel();
+
+        // onError should not be called.
+        originalCompleter.completeError('error');
+      });
+    });
+
+    group('original operation canceled', () {
+      test('onCancel not set', () async {
+        onCancel = null;
+
+        final operation = runThenOperation();
+
+        await expectLater(originalCompleter.operation.cancel(), completes);
+        expect(operation.isCanceled, true);
+      });
+
+      test('onCancel completes successfully', () {
+        onCancel = expectAsync1((c) => c.complete('canceled'),
+            count: 1, id: 'onCancel');
+
+        expect(runThenOperation().value, completion('canceled'));
+        originalCompleter.operation.cancel();
+      });
+
+      test('onCancel throws error', () {
+        // expectAsync0 only works with functions that do not throw.
+        onCancel = (_) => throw 'error';
+
+        expect(runThenOperation().value, throwsA('error'));
+        originalCompleter.operation.cancel();
+      });
+
+      test('onCancel completes operation as error', () {
+        onCancel = expectAsync1((c) => c.completeError('error'),
+            count: 1, id: 'onCancel');
+
+        expect(runThenOperation().value, throwsA('error'));
+        originalCompleter.operation.cancel();
+      });
+
+      test('after completing with a future does not invoke `onValue`',
+          () async {
+        onValue = expectAsync2((_, __) {}, count: 0);
+        onCancel = null;
+        var operation = runThenOperation();
+        var workCompleter = Completer<int>();
+        originalCompleter.complete(workCompleter.future);
+        var cancelation = originalCompleter.operation.cancel();
+        expect(originalCompleter.isCanceled, true);
+        workCompleter.complete(0);
+        await cancelation;
+        expect(operation.isCanceled, true);
+        await workCompleter.future;
+      });
+
+      test('after the value is completed invokes `onValue`', () {
+        onValue = expectAsync2((v, c) => c.complete('foo'), count: 1);
+        onCancel = expectAsync1((_) {}, count: 0);
+        originalCompleter.complete(0);
+        originalCompleter.operation.cancel();
+        var operation = runThenOperation();
+        expect(operation.value, completion('foo'));
+        expect(operation.isCanceled, false);
+      });
+    });
+
+    group('returned operation canceled', () {
+      test('propagateCancel is true', () async {
+        propagateCancel = true;
+
+        await runThenOperation().cancel();
+
+        expect(originalCompleter.isCanceled, true);
+      });
+
+      test('propagateCancel is false', () async {
+        propagateCancel = false;
+
+        await runThenOperation().cancel();
+
+        expect(originalCompleter.isCanceled, false);
+      });
+
+      test('onValue callback not called after cancel', () async {
+        onValue = expectAsync2((_, c) {}, count: 0);
+
+        await runThenOperation().cancel();
+        originalCompleter.complete(0);
+      });
+
+      test('onError callback not called after cancel', () async {
+        onError = expectAsync3((_, __, ___) {}, count: 0);
+
+        await runThenOperation().cancel();
+        originalCompleter.completeError("Error", StackTrace.empty);
+      });
+
+      test('onCancel callback not called after cancel', () async {
+        onCancel = expectAsync1((_) {}, count: 0);
+
+        await runThenOperation().cancel();
+        await originalCompleter.operation.cancel();
+      });
+    });
+  });
+
   group('race()', () {
     late bool canceled1;
     late CancelableCompleter<int> completer1;

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -501,7 +501,6 @@ void main() {
         onValue = expectAsync1((_) {
           called = true;
           fail("onValue unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();
@@ -515,7 +514,6 @@ void main() {
         onError = expectAsync2((_, __) {
           called = true;
           fail("onError unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();
@@ -529,7 +527,6 @@ void main() {
         onCancel = expectAsync0(() {
           called = true;
           fail("onCancel unreachable");
-          return "";
         }, count: 0);
 
         await runThen().cancel();


### PR DESCRIPTION
Towards #210

Once combined with `Completer.completeOperation` this signature adds
significant flexibility for chaining Cancelable work following other
async work.

Move the existing `.then` implementation to `.thenOperation` since the latter
is more general.