### PR TITLE
Add CancelableCompleter.completeOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `CancelableOperation.thenOperation` which gives more flexibility to
   complete the resulting operation.
+* Add `CancelableCompleter.completeOperation`.
 
 ## 2.9.0
 

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -418,6 +418,33 @@ class CancelableCompleter<T> {
     });
   }
 
+  /// Makes this [CancelableCompleter.operation] complete with the same result
+  /// as [result].
+  ///
+  /// If the operation of this completer is cancelled before [result] completes,
+  /// then if [propagateCancel] is set to true, [result] is also cancelled.
+  void completeOperation(CancelableOperation<T> result,
+      {bool propagateCancel = true}) {
+    if (!_mayComplete) throw StateError("Already completed");
+    _mayComplete = false;
+    if (isCanceled) {
+      if (propagateCancel) result.cancel();
+      result.value.ignore();
+      return;
+    }
+    result.then<void>((value) {
+      _inner?.complete(
+          value); // _inner is set to null if this.operation is cancelled.
+    }, onError: (error, stack) {
+      _inner?.completeError(error, stack);
+    }, onCancel: () {
+      operation.cancel();
+    });
+    if (propagateCancel) {
+      _cancelCompleter?.future.whenComplete(result.cancel);
+    }
+  }
+
   /// Completer to use for completing with a result.
   ///
   /// Returns `null` if it's not possible to complete any more.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -421,8 +421,9 @@ class CancelableCompleter<T> {
   /// Makes this [CancelableCompleter.operation] complete with the same result
   /// as [result].
   ///
-  /// If the operation of this completer is cancelled before [result] completes,
-  /// then if [propagateCancel] is set to true, [result] is also cancelled.
+  /// If [propagateCancel] is `true` (the default), and the [operation] of this
+  /// completer is canceled before [result] completes, then [result] is also
+  /// canceled.
   void completeOperation(CancelableOperation<T> result,
       {bool propagateCancel = true}) {
     if (!_mayComplete) throw StateError("Already completed");


### PR DESCRIPTION
Towards #210

Combined with `CancelableOperation.thenOperation` this allows chaining
cancelable work that can be canceled at multiple points.