### PR TITLE
Add CancelableOperation.fromValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add `CancelableOperation.thenOperation` which gives more flexibility to
   complete the resulting operation.
 * Add `CancelableCompleter.completeOperation`.
+* Add `CancelableOperation.fromValue`.
 * Require Dart 2.18
 
 ## 2.9.0

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -25,13 +25,22 @@ class CancelableOperation<T> {
   /// If [onCancel] returns a [Future], it will be returned by [cancel].
   ///
   /// The [onCancel] funcion will be called synchronously
-  /// when the new operation is canceled, and will be called at most once.\
+  /// when the new operation is canceled, and will be called at most once.
   ///
   /// Calling this constructor is equivalent to creating a
   /// [CancelableCompleter] and completing it with [result].
   factory CancelableOperation.fromFuture(Future<T> result,
           {FutureOr Function()? onCancel}) =>
       (CancelableCompleter<T>(onCancel: onCancel)..complete(result)).operation;
+
+  /// Creates a [CancelableOperation] which completes to [value].
+  ///
+  /// Canceling this operation does nothing.
+  ///
+  /// Calling this constructor is equivalent to creating a
+  /// [CancelableCompleter] and completing it with [value].
+  factory CancelableOperation.fromValue(T value) =>
+      (CancelableCompleter<T>()..complete(value)).operation;
 
   /// Creates a [CancelableOperation] wrapping [subscription].
   ///


### PR DESCRIPTION
This is useful in tests which stub behavior for an API which returns `CancelableOperation`. It has more clear semantics and is shorter than `CancelableOperation.fromFuture(Future.value(...))`.

Take a `T` instead of a more general `FutureOr<T>` to satisfy both cases because it allows simplifying the API with no `onCancel` support.