### PR TITLE
update changelog and pubspec version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 2.11.0-dev
+
+* Add `CancelableOperation.fromValue`.
+
 ## 2.10.0
 
 * Add `CancelableOperation.thenOperation` which gives more flexibility to
   complete the resulting operation.
 * Add `CancelableCompleter.completeOperation`.
-* Add `CancelableOperation.fromValue`.
 * Require Dart 2.18
 
 ## 2.9.0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Contains utility classes in the style of `dart:async` to work with asynchronous
 computations.
 
+## Package API
+
 * The [`AsyncCache`][AsyncCache] class allows expensive asynchronous
   computations values to be cached for a period of time.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: async
-version: 2.10.0
-
+version: 2.11.0-dev
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
 


### PR DESCRIPTION
It looks like https://github.com/dart-lang/async/commit/c59c7c51cc2a1b1fc49a2d853d413bd3a92126e9 landed after the last publish; this PR moves the changelog entry into a new section - `2.11.0-dev`. If we want to republish immediately w/ the new version, we can instead rev to `2.11.0` in this PR.