### PR TITLE
Simplify implementation of `StreamQueue`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 2.11.0-dev
 
 * Add `CancelableOperation.fromValue`.
+* Simplify implementation of `StreamQueue`.
+  Remaining queues of committed or rejected transactions now see all events 
+  delivered up to the point where the transaction was completed.
 
 ## 2.10.0
 


### PR DESCRIPTION
Only change in behavior is that all event seen by the original queue while the transaction request is active, are forwarded to the transaction immediately, and will still be visible after the transaction commits or rejects.

The existing behavior was based on cancelling a stream subscription and which events were visible depended on which commands had been used to request those events already.