### PR TITLE
Add `StreamExtensions.buffer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Add `CancelableOperation.fromValue`.
 
-* Add `StreamExtensions.buffer`, which buffers events from a stream before it
-  has a listener.
+* Add `StreamExtensions.listenAndBuffer`, which buffers events from a stream
+  before it has a listener.
 
 ## 2.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.11.0
 
 * Add `CancelableOperation.fromValue`.
-
 * Add `StreamExtensions.listenAndBuffer`, which buffers events from a stream
   before it has a listener.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 2.11.0-dev
+## 2.11.0
 
 * Add `CancelableOperation.fromValue`.
+
+* Add `StreamExtensions.buffer`, which buffers events from a stream before it
+  has a listener.
 
 ## 2.10.0
 

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -62,6 +62,11 @@ extension StreamExtensions<T> on Stream<T> {
   /// stream is listened to, at which point all buffered events will be emitted
   /// in order, and then further events from this stream will be emitted as they
   /// arrive.
+  ///
+  /// The buffer will retain all events until the returned stream is listened
+  /// to, so if the stream can emit arbitrary amounts of data callers should be
+  /// careful to listen to it eventually or call `stream.listen(null).cancel()`
+  /// to discard it if it's not needed.
   Stream<T> bufferUntilListen() {
     var controller = StreamController<T>(sync: true);
     var subscription = listen(controller.add,

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -64,9 +64,10 @@ extension StreamExtensions<T> on Stream<T> {
   /// arrive.
   ///
   /// The buffer will retain all events until the returned stream is listened
-  /// to, so if the stream can emit arbitrary amounts of data callers should be
-  /// careful to listen to it eventually or call `stream.listen(null).cancel()`
-  /// to discard it if it's not needed.
+  /// to, so if the stream can emit arbitrary amounts of data, callers should be
+  /// careful to listen to the stream eventually or call
+  /// `stream.listen(null).cancel()` to discard the buffered data if it becomes
+  /// clear that the data isn't not needed.
   Stream<T> bufferUntilListen() {
     var controller = StreamController<T>(sync: true);
     var subscription = listen(controller.add,

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -68,7 +68,7 @@ extension StreamExtensions<T> on Stream<T> {
   /// careful to listen to the stream eventually or call
   /// `stream.listen(null).cancel()` to discard the buffered data if it becomes
   /// clear that the data isn't not needed.
-  Stream<T> bufferUntilListen() {
+  Stream<T> listenAndBuffer() {
     var controller = StreamController<T>(sync: true);
     var subscription = listen(controller.add,
         onError: controller.addError, onDone: controller.close);

--- a/lib/src/stream_extensions.dart
+++ b/lib/src/stream_extensions.dart
@@ -54,4 +54,17 @@ extension StreamExtensions<T> on Stream<T> {
     });
     return completer.future;
   }
+
+  /// Returns a view of this stream that eagerly buffers all events until
+  /// `listen()` is called.
+  Stream<T> buffer() {
+    late StreamSubscription<T> subscription;
+    var controller = StreamController<T>(
+        onPause: () => subscription.pause(),
+        onResume: () => subscription.resume(),
+        onCancel: () => subscription.cancel());
+    subscription = listen(controller.add,
+        onError: controller.addError, onDone: controller.close);
+    return controller.stream;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.11.0-dev
+version: 2.11.0
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
 

--- a/test/stream_extensions_test.dart
+++ b/test/stream_extensions_test.dart
@@ -93,24 +93,24 @@ void main() {
     });
   });
 
-  group('.bufferUntilListen', () {
-    test('emits events added before the bufferUntilListen is listened',
+  group('.listenAndBuffer', () {
+    test('emits events added before the listenAndBuffer is listened',
         () async {
       var controller = StreamController<int>()
         ..add(1)
         ..add(2)
         ..add(3)
         ..close();
-      var stream = controller.stream.bufferUntilListen();
+      var stream = controller.stream.listenAndBuffer();
       await pumpEventQueue();
 
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
     });
 
-    test('emits events added after the bufferUntilListen is listened',
+    test('emits events added after the listenAndBuffer is listened',
         () async {
       var controller = StreamController<int>();
-      var stream = controller.stream.bufferUntilListen();
+      var stream = controller.stream.listenAndBuffer();
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
       await pumpEventQueue();
 
@@ -122,13 +122,13 @@ void main() {
     });
 
     test(
-        'emits events added before and after the bufferUntilListen is listened',
+        'emits events added before and after the listenAndBuffer is listened',
         () async {
       var controller = StreamController<int>()
         ..add(1)
         ..add(2)
         ..add(3);
-      var stream = controller.stream.bufferUntilListen();
+      var stream = controller.stream.listenAndBuffer();
       expectLater(stream, emitsInOrder([1, 2, 3, 4, 5, 6, emitsDone]));
       await pumpEventQueue();
 
@@ -139,18 +139,18 @@ void main() {
         ..close();
     });
 
-    test('listens as soon as bufferUntilListen() is called', () async {
+    test('listens as soon as listenAndBuffer() is called', () async {
       var listened = false;
       var controller = StreamController<int>(onListen: () {
         listened = true;
       });
-      controller.stream.bufferUntilListen();
+      controller.stream.listenAndBuffer();
       expect(listened, isTrue);
     });
 
     test('forwards pause and resume', () async {
       var controller = StreamController<int>();
-      var stream = controller.stream.bufferUntilListen();
+      var stream = controller.stream.listenAndBuffer();
       expect(controller.isPaused, isFalse);
       var subscription = stream.listen(null);
       expect(controller.isPaused, isFalse);
@@ -167,7 +167,7 @@ void main() {
         canceled = true;
         return completer.future;
       });
-      var stream = controller.stream.bufferUntilListen();
+      var stream = controller.stream.listenAndBuffer();
       expect(canceled, isFalse);
       var subscription = stream.listen(null);
       expect(canceled, isFalse);

--- a/test/stream_extensions_test.dart
+++ b/test/stream_extensions_test.dart
@@ -92,4 +92,94 @@ void main() {
       expect(isCancelled, isTrue);
     });
   });
+
+  group('.buffer', () {
+    test('emits events added before the buffer is listened', () async {
+      var controller = StreamController<int>()
+        ..add(1)
+        ..add(2)
+        ..add(3)
+        ..close();
+      var stream = controller.stream.buffer();
+      await pumpEventQueue();
+
+      expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
+    });
+
+    test('emits events added after the buffer is listened', () async {
+      var controller = StreamController<int>();
+      var stream = controller.stream.buffer();
+      expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
+      await pumpEventQueue();
+
+      controller
+        ..add(1)
+        ..add(2)
+        ..add(3)
+        ..close();
+    });
+
+    test('emits events added before and after the buffer is listened',
+        () async {
+      var controller = StreamController<int>()
+        ..add(1)
+        ..add(2)
+        ..add(3);
+      var stream = controller.stream.buffer();
+      expectLater(stream, emitsInOrder([1, 2, 3, 4, 5, 6, emitsDone]));
+      await pumpEventQueue();
+
+      controller
+        ..add(4)
+        ..add(5)
+        ..add(6)
+        ..close();
+    });
+
+    test('listens as soon as buffer() is called', () async {
+      var listened = false;
+      var controller = StreamController<int>(onListen: () {
+        listened = true;
+      });
+      controller.stream.buffer();
+      expect(listened, isTrue);
+    });
+
+    test('forwards pause and resume', () async {
+      var controller = StreamController<int>();
+      var stream = controller.stream.buffer();
+      expect(controller.isPaused, isFalse);
+      var subscription = stream.listen(null);
+      expect(controller.isPaused, isFalse);
+      subscription.pause();
+      expect(controller.isPaused, isTrue);
+      subscription.resume();
+      expect(controller.isPaused, isFalse);
+    });
+
+    test('forwards cancel', () async {
+      var completer = new Completer<void>();
+      var canceled = false;
+      var controller = StreamController<int>(onCancel: () {
+        canceled = true;
+        return completer.future;
+      });
+      var stream = controller.stream.buffer();
+      expect(canceled, isFalse);
+      var subscription = stream.listen(null);
+      expect(canceled, isFalse);
+
+      var cancelCompleted = false;
+      subscription.cancel().then((_) {
+        cancelCompleted = true;
+      });
+      expect(canceled, isTrue);
+      await pumpEventQueue();
+      expect(cancelCompleted, isFalse);
+
+      completer.complete();
+      await pumpEventQueue();
+      expect(cancelCompleted, isTrue);
+    });
+  });
 }

--- a/test/stream_extensions_test.dart
+++ b/test/stream_extensions_test.dart
@@ -158,7 +158,7 @@ void main() {
     });
 
     test('forwards cancel', () async {
-      var completer = new Completer<void>();
+      var completer = Completer<void>();
       var canceled = false;
       var controller = StreamController<int>(onCancel: () {
         canceled = true;

--- a/test/stream_extensions_test.dart
+++ b/test/stream_extensions_test.dart
@@ -94,8 +94,7 @@ void main() {
   });
 
   group('.listenAndBuffer', () {
-    test('emits events added before the listenAndBuffer is listened',
-        () async {
+    test('emits events added before the listenAndBuffer is listened', () async {
       var controller = StreamController<int>()
         ..add(1)
         ..add(2)
@@ -107,8 +106,7 @@ void main() {
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
     });
 
-    test('emits events added after the listenAndBuffer is listened',
-        () async {
+    test('emits events added after the listenAndBuffer is listened', () async {
       var controller = StreamController<int>();
       var stream = controller.stream.listenAndBuffer();
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
@@ -121,8 +119,7 @@ void main() {
         ..close();
     });
 
-    test(
-        'emits events added before and after the listenAndBuffer is listened',
+    test('emits events added before and after the listenAndBuffer is listened',
         () async {
       var controller = StreamController<int>()
         ..add(1)

--- a/test/stream_extensions_test.dart
+++ b/test/stream_extensions_test.dart
@@ -93,22 +93,24 @@ void main() {
     });
   });
 
-  group('.buffer', () {
-    test('emits events added before the buffer is listened', () async {
+  group('.bufferUntilListen', () {
+    test('emits events added before the bufferUntilListen is listened',
+        () async {
       var controller = StreamController<int>()
         ..add(1)
         ..add(2)
         ..add(3)
         ..close();
-      var stream = controller.stream.buffer();
+      var stream = controller.stream.bufferUntilListen();
       await pumpEventQueue();
 
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
     });
 
-    test('emits events added after the buffer is listened', () async {
+    test('emits events added after the bufferUntilListen is listened',
+        () async {
       var controller = StreamController<int>();
-      var stream = controller.stream.buffer();
+      var stream = controller.stream.bufferUntilListen();
       expectLater(stream, emitsInOrder([1, 2, 3, emitsDone]));
       await pumpEventQueue();
 
@@ -119,13 +121,14 @@ void main() {
         ..close();
     });
 
-    test('emits events added before and after the buffer is listened',
+    test(
+        'emits events added before and after the bufferUntilListen is listened',
         () async {
       var controller = StreamController<int>()
         ..add(1)
         ..add(2)
         ..add(3);
-      var stream = controller.stream.buffer();
+      var stream = controller.stream.bufferUntilListen();
       expectLater(stream, emitsInOrder([1, 2, 3, 4, 5, 6, emitsDone]));
       await pumpEventQueue();
 
@@ -136,18 +139,18 @@ void main() {
         ..close();
     });
 
-    test('listens as soon as buffer() is called', () async {
+    test('listens as soon as bufferUntilListen() is called', () async {
       var listened = false;
       var controller = StreamController<int>(onListen: () {
         listened = true;
       });
-      controller.stream.buffer();
+      controller.stream.bufferUntilListen();
       expect(listened, isTrue);
     });
 
     test('forwards pause and resume', () async {
       var controller = StreamController<int>();
-      var stream = controller.stream.buffer();
+      var stream = controller.stream.bufferUntilListen();
       expect(controller.isPaused, isFalse);
       var subscription = stream.listen(null);
       expect(controller.isPaused, isFalse);
@@ -164,7 +167,7 @@ void main() {
         canceled = true;
         return completer.future;
       });
-      var stream = controller.stream.buffer();
+      var stream = controller.stream.bufferUntilListen();
       expect(canceled, isFalse);
       var subscription = stream.listen(null);
       expect(canceled, isFalse);


### PR DESCRIPTION
The immediate motivation for this is to buffer stderr from a subprocess until we learn whether the subprocess completed successfully or not. It's important to consume the output eagerly so the process doesn't deadlock after saturating the OS and/or `dart:io` buffers, but we don't want to print it at all if the process completes successfully.

I think it's generally useful to have an explicit way of doing this, since otherwise users may naively try to write `Stream.pipe(StreamController)` which doesn't actually buffer output if the controller doesn't have a listener.