### PR TITLE
Synchronously forward chained cancellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.12.0-dev
+
 ## 2.11.0
 
 * Add `CancelableOperation.fromValue`.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -230,8 +230,7 @@ class CancelableOperation<T> {
       FutureOr<void> Function(CancelableCompleter<R>)? onCancel,
       bool propagateCancel = true}) {
     final completer = CancelableCompleter<R>(
-        onCancel:
-            propagateCancel ? (() => !isCanceled ? cancel() : null) : null);
+        onCancel: propagateCancel ? _cancelIfNotCanceled : null);
 
     // if `_completer._inner` completes before `completer` is cancelled
     // call `onValue` or `onError` with the result, and complete `completer`
@@ -283,6 +282,8 @@ class CancelableOperation<T> {
   /// If this operation [isCompleted] or [isCanceled] this call is ignored.
   /// Returns the result of the `onCancel` callback, if one exists.
   Future cancel() => _completer._cancel();
+
+  Future<void>? _cancelIfNotCanceled() => isCanceled ? null : cancel();
 
   /// Whether this operation has been canceled before it completed.
   bool get isCanceled => _completer._isCanceled;

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -345,7 +345,7 @@ class CancelableCompleter<T> {
   /// The callback to call if the operation is canceled.
   final FutureOr<void> Function()? _onCancel;
 
-  /// Additional cancellations to forward during cancel;
+  /// Additional cancellations to forward during cancel.
   ///
   /// When a cancelable operation is chained through `then` or `thenOperation` a
   /// cancellation on the original operation will synchronously cancel the
@@ -512,7 +512,7 @@ class CancelableCompleter<T> {
     return cancelCompleter.future;
   }
 
-  /// Invoke [_onCancel] and all callbacks in [_cancelForwarders].
+  /// Invoke [_onCancel] and forward to other completers in [_cancelForwarders].
   ///
   /// Returns the same value as [_onCancel]. Legacy uses may return a value
   /// despite the signature having `void` return.

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -349,7 +349,7 @@ class CancelableCompleter<T> {
   /// ever complete.
   /// Set to `null` when [_inner] is completed, because then it's
   /// guaranteed that this completer will never complete.
-  Completer<void>? _cancelCompleter = Completer<void>();
+  Completer<Object?>? _cancelCompleter = Completer<Object?>();
 
   /// The callback to call if the operation is canceled.
   final FutureOr<void> Function()? _onCancel;
@@ -524,7 +524,7 @@ class CancelableCompleter<T> {
         return toReturn is Future ? await toReturn : toReturn;
       }
 
-      cancelCompleter.complete(Future.sync(allCancels));
+      cancelCompleter.complete(allCancels());
     }
     return cancelCompleter.future;
   }

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -280,7 +280,7 @@ class CancelableOperation<T> {
             }
           };
     if (_completer.isCanceled) {
-      Future(forwardingCancel);
+      forwardingCancel();
     } else {
       _completer._extraOnCancel.add(forwardingCancel);
     }

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -553,7 +553,8 @@ class _CancelForwarder<T> {
   }
 }
 
-Future<void>? _forward<T>(_CancelForwarder<T> forwarder) =>
+// Helper function to avoid a closure for  `List<_CancelForwarder>.map`.
+Future<void>? _forward(_CancelForwarder<Object?> forwarder) =>
     forwarder._forward();
 
 extension on CancelableCompleter {

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -528,12 +528,11 @@ class _CancelForwarder<T> {
   final CancelableCompleter<T> completer;
   final FutureOr<void> Function(CancelableCompleter<T>)? onCancel;
   _CancelForwarder(this.completer, this.onCancel);
+
   Future<void>? _forward() {
     if (completer.isCanceled) return null;
     final onCancel = this.onCancel;
-    if (onCancel == null) {
-      return completer._cancel();
-    }
+    if (onCancel == null) return completer._cancel();
     try {
       final result = onCancel(completer);
       if (result is Future) {

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -521,7 +521,7 @@ class CancelableCompleter<T> {
         if (_extraOnCancel.isNotEmpty) {
           await Future.wait(_extraOnCancel.map((c) => c()).whereNotNull());
         }
-        return await toReturn;
+        return toReturn is Future ? await toReturn : toReturn;
       }
 
       cancelCompleter.complete(Future.sync(allCancels));

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -263,8 +263,7 @@ class CancelableOperation<T> {
                 try {
                   await onError(error, stack, completer);
                 } catch (error2, stack2) {
-                  if (completer.isCompleted) return;
-                  completer.completeError(
+                  completer.completeErrorIfPending(
                       error2, identical(error, error2) ? stack : stack2);
                 }
               });

--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -271,7 +271,7 @@ class CancelableOperation<T> {
     if (_completer.isCanceled) {
       cancelForwarder._forward();
     } else {
-      _completer._cancelForwarders.add(cancelForwarder);
+      (_completer._cancelForwarders ??= []).add(cancelForwarder);
     }
     return completer.operation;
   }
@@ -350,7 +350,7 @@ class CancelableCompleter<T> {
   /// When a cancelable operation is chained through `then` or `thenOperation` a
   /// cancellation on the original operation will synchronously cancel the
   /// chained operations.
-  final List<_CancelForwarder> _cancelForwarders = [];
+  List<_CancelForwarder>? _cancelForwarders;
 
   /// Whether [complete] or [completeError] may still be called.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: async
-version: 2.11.0
+version: 2.12.0-dev
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ^3.0.0-417
 
 dependencies:
   collection: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/async
 
 environment:
-  sdk: ^3.0.0-417
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/test/cancelable_operation_test.dart
+++ b/test/cancelable_operation_test.dart
@@ -568,6 +568,17 @@ void main() {
         expect(operation.value, completion('foo'));
         expect(operation.isCanceled, false);
       });
+
+      test('waits for chained cancellation', () async {
+        var completer = CancelableCompleter<void>();
+        var chainedOperation = completer.operation
+            .then((_) => Future.delayed(Duration(milliseconds: 1)))
+            .then((_) => Future.delayed(Duration(milliseconds: 1)));
+
+        await completer.operation.cancel();
+        expect(completer.operation.isCanceled, true);
+        expect(chainedOperation.isCanceled, true);
+      });
     });
 
     group('returned operation canceled', () {


### PR DESCRIPTION
Add a test which chains through multiple `.then` calls and then cancels
the original operation. This test passes with the original code, but
starts failing after fixing a bug in `Completer.complete` in the SDK.
https://dart-review.googlesource.com/c/sdk/+/258929

- Add a list of extra completers to forward cancellation. In places
  where the cancellation had been forwarded through a `whenComplete`,
  add to the list of extra cancellations instead. This allows the Future
  return by the outer cancellation to wait for the other callbacks to
  complete before firing.
- When setting up forwarding on an already canceled completer,
  immediately forward the cancellation.
- When forwarding cancellations, don't repeatedly call `_cancel()` on a
  completer which has already been canceled.
- In `race()`, disable cancellation propagation to prevent a cyclic
  cancellation.
