### PR TITLE
docs: fix typo in CancelableOperation.fromFuture(...) docs

### DIFF
--- a/lib/src/cancelable_operation.dart
+++ b/lib/src/cancelable_operation.dart
@@ -26,7 +26,7 @@ class CancelableOperation<T> {
   /// or error later produced by [result] will be discarded.
   /// If [onCancel] returns a [Future], it will be returned by [cancel].
   ///
-  /// The [onCancel] funcion will be called synchronously
+  /// The [onCancel] function will be called synchronously
   /// when the new operation is canceled, and will be called at most once.
   ///
   /// Calling this constructor is equivalent to creating a


### PR DESCRIPTION
Just fixes a typo in the docs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
