### PR TITLE
Async cache won't store exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.12.0-wip
 
 - Require Dart 2.19
-- `fetch` method of `AsyncCache` will no longer store exception.
+- Can decide `fetch` method of `AsyncCache` will store exception or not.
 
 ## 2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.12.0-wip
 
 - Require Dart 2.19
+- `fetch` method of `AsyncCache` will no longer store exception.
 
 ## 2.11.0
 

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -42,7 +42,7 @@ class AsyncCache<T> {
   ///If we set this variable to false
   ///On the initial run, if callback returned the [Exception]
   ///Next time, we can reRun the callback for the successful attempt.
-  final bool _canCacheException;
+  final bool _cacheErrors;
 
   /// Fires when the cache should be considered stale.
   Timer? _stale;
@@ -52,9 +52,9 @@ class AsyncCache<T> {
   /// The [duration] starts counting after the Future returned by [fetch]
   /// completes, or after the Stream returned by `fetchStream` emits a done
   /// event.
-  AsyncCache(Duration duration, {bool canCacheException = true})
+  AsyncCache(Duration duration, {bool cacheErrors = true})
       : _duration = duration,
-        _canCacheException = canCacheException;
+        _cacheErrors = cacheErrors;
 
   /// Creates a cache that invalidates after an in-flight request is complete.
   ///
@@ -63,7 +63,7 @@ class AsyncCache<T> {
   /// data is updated frequently but stale data is acceptable.
   AsyncCache.ephemeral()
       : _duration = null,
-        _canCacheException = true;
+        _cacheErrors = true;
 
   /// Returns a cached value from a previous call to [fetch], or runs [callback]
   /// to compute a new one.
@@ -74,7 +74,7 @@ class AsyncCache<T> {
     if (_cachedStreamSplitter != null) {
       throw StateError('Previously used to cache via `fetchStream`');
     }
-    if (_canCacheException) {
+    if (_cacheErrors) {
       return _cachedValueFuture ??= callback()
         ..whenComplete(_startStaleTimer).ignore();
     } else {

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -38,10 +38,10 @@ class AsyncCache<T> {
   /// Cached results of a previous [fetch] call.
   Future<T>? _cachedValueFuture;
 
-  ///Default is set to true
-  ///If we set this variable to false
-  ///On the initial run, if callback returned the [Exception]
-  ///Next time, we can reRun the callback for the successful attempt.
+  /// Default is set to true
+  /// If this variable is set to false,
+  /// and callback gets completed with an error,
+  /// then the response will not get cached.
   final bool _cacheErrors;
 
   /// Fires when the cache should be considered stale.

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -38,10 +38,13 @@ class AsyncCache<T> {
   /// Cached results of a previous [fetch] call.
   Future<T>? _cachedValueFuture;
 
-  /// Default is set to true
-  /// If this variable is set to false,
-  /// and callback gets completed with an error,
-  /// then the response will not get cached.
+  /// Whether the cache will keep a future completed with an error.
+  ///
+  /// If `false`, a non-ephemeral cache will clear the cached future
+  /// immediately if the future completes with an error, as if the
+  /// caching was ephemeral.
+  /// _(Ephemeral caches always clear when the future completes,
+  /// so this flag has no effect on those.)_
   final bool _cacheErrors;
 
   /// Fires when the cache should be considered stale.

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -82,13 +82,12 @@ class AsyncCache<T> {
         try {
           ///First we run the callback then we assign the value received
           ///from [callback] to the [_cachedValueFuture]
-          T value = await callback();
+          var value = await callback();
           _cachedValueFuture ??= Future.value(value);
           _startStaleTimer();
           return _cachedValueFuture!;
-
-          ///If [callback] generated an exception then we should not cache data
-          ///And propagate exception to the place from where [fetch] is triggered
+        ///If [callback] generated an exception then we should not cache data
+        ///And propagate exception to the place from where [fetch] is triggered
         } catch (error) {
           rethrow;
         }

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -7,9 +7,7 @@ import 'dart:async';
 import '../async.dart';
 
 /// Runs asynchronous functions and caches the result for a period of time.
-/// If you doesn't want to cache Exception then you can set
-// [_canCacheException] to false.
-//
+///
 /// This class exists to cover the pattern of having potentially expensive code
 /// such as file I/O, network access, or isolate computation that's unlikely to
 /// change quickly run fewer times. For example:

--- a/lib/src/async_cache.dart
+++ b/lib/src/async_cache.dart
@@ -53,6 +53,8 @@ class AsyncCache<T> {
   /// The [duration] starts counting after the Future returned by [fetch]
   /// completes, or after the Stream returned by `fetchStream` emits a done
   /// event.
+  /// If [cacheErrors] is `false` the cache will be invalidated if the [Future]
+  /// returned by the callback completes as an error.
   AsyncCache(Duration duration, {bool cacheErrors = true})
       : _duration = duration,
         _cacheErrors = cacheErrors;

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -19,7 +19,6 @@ void main() {
   });
 
   test('should not fetch when callback throws exception', () async {
-
     cache = AsyncCache(const Duration(hours: 1), cacheErrors: false);
 
     Future<String> asyncFunctionThatThrows() {

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -18,6 +18,14 @@ void main() {
     cache = AsyncCache(const Duration(hours: 1));
   });
 
+  test('should not fetch when callback throws exception', () async {
+    Future<String> asyncFunctionThatThrows() {
+      throw Exception();
+    }
+    var cacheFuture = cache.fetch(asyncFunctionThatThrows);
+    await expectLater(cacheFuture,throwsA(isException));
+  });
+
   test('should fetch via a callback when no cache exists', () async {
     expect(await cache.fetch(() async => 'Expensive'), 'Expensive');
   });

--- a/test/async_cache_test.dart
+++ b/test/async_cache_test.dart
@@ -19,11 +19,18 @@ void main() {
   });
 
   test('should not fetch when callback throws exception', () async {
+
+    cache = AsyncCache(const Duration(hours: 1), cacheErrors: false);
+
     Future<String> asyncFunctionThatThrows() {
       throw Exception();
     }
-    var cacheFuture = cache.fetch(asyncFunctionThatThrows);
-    await expectLater(cacheFuture,throwsA(isException));
+
+    var errorThrowingFuture = cache.fetch(asyncFunctionThatThrows);
+    await expectLater(errorThrowingFuture, throwsA(isException));
+
+    var valueFuture = cache.fetch(() async => 'Success');
+    expect(await valueFuture, 'Success');
   });
 
   test('should fetch via a callback when no cache exists', () async {


### PR DESCRIPTION
Earlier async cache was caching exceptions.
With new changes in `fetch` method of `AsyncCache` class will no longer store exception.
By default `AsyncCache` will store exception, by setting `_canCacheException` to false. It won't store exception.

Please refer #257 for video demo of both issue and solution along with minimal reproducible code.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

