### PR TITLE
Fix/async memoizer storing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.12.0-wip
 
 - Require Dart 2.19
+- `runOnce` method of `AsyncMemoizer` will no longer store exception.
 
 ## 2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.12.0-wip
 
 - Require Dart 2.19
-- `runOnce` method of `AsyncMemoizer` will no longer store exception.
+- Can decide `runOnce` method of `AsyncMemoizer` will store exception or not.
 
 ## 2.11.0
 

--- a/lib/src/async_memoizer.dart
+++ b/lib/src/async_memoizer.dart
@@ -5,7 +5,9 @@
 import 'dart:async';
 
 /// A class for running an asynchronous function exactly once and caching its
-/// result.
+/// result. If you doesn't want to cache Exception then you can set
+/// [_canCacheException] to false.
+///
 ///
 /// An `AsyncMemoizer` is used when some function may be run multiple times in
 /// order to get its result, but it only actually needs to be run once for its
@@ -39,9 +41,9 @@ class AsyncMemoizer<T> {
   /// Whether [runOnce] has been called yet.
   bool get hasRun => _completer.isCompleted;
 
-  ///Default is set to true
-  ///If we set this variable to false
-  ///On the initial run, if callback returned the [Exception]
+  ///Default is set to true.
+  ///If we set this variable to false.
+  ///On the initial run, if callback returned the [Exception].
   ///Next time, we can reRun the callback for the successful attempt.
   final bool _canCacheException;
 

--- a/lib/src/async_memoizer.dart
+++ b/lib/src/async_memoizer.dart
@@ -56,7 +56,7 @@ class AsyncMemoizer<T> {
         _completer.complete(Future.sync(computation));
       } else {
         try {
-          T value = await computation();
+          var value = await computation();
           _completer.complete(value);
         } catch (error) {
           rethrow;

--- a/lib/src/async_memoizer.dart
+++ b/lib/src/async_memoizer.dart
@@ -39,8 +39,15 @@ class AsyncMemoizer<T> {
   /// Runs the function, [computation], if it hasn't been run before.
   ///
   /// If [runOnce] has already been called, this returns the original result.
-  Future<T> runOnce(FutureOr<T> Function() computation) {
-    if (!hasRun) _completer.complete(Future.sync(computation));
-    return future;
+  Future<T> runOnce(FutureOr<T> Function() computation) async{
+    if(!hasRun){
+      try{
+        T value =  await computation();
+        _completer.complete(value);
+      } catch (error){
+        rethrow;
+      }
+    }
+      return future;
   }
 }

--- a/test/async_memoizer_test.dart
+++ b/test/async_memoizer_test.dart
@@ -9,6 +9,14 @@ void main() {
   late AsyncMemoizer cache;
   setUp(() => cache = AsyncMemoizer());
 
+  test('should not store exception when callback throws exception', () async {
+    Future<String> asyncFunctionThatThrows() {
+      throw Exception();
+    }
+    var cacheFuture = cache.runOnce(asyncFunctionThatThrows);
+    await expectLater(cacheFuture,throwsA(isException));
+  });
+
   test('runs the function only the first time runOnce() is called', () async {
     var count = 0;
     expect(await cache.runOnce(() => count++), equals(0));


### PR DESCRIPTION
Earlier asyncMemoizer was caching exceptions.
With new changes in `runOnce` method of `AsyncMemoizer` class will no longer store exception.
By default `AsyncMemoizer` will store exception, by setting `_canCacheException` to false. It won't store exception.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
