### PR TITLE
`CaptureExtension` added into `Future<T>`

### DIFF
--- a/lib/async.dart
+++ b/lib/async.dart
@@ -26,6 +26,7 @@ export 'src/null_stream_sink.dart';
 export 'src/restartable_timer.dart';
 export 'src/result/error.dart';
 export 'src/result/future.dart';
+export 'src/result/future_extension.dart';
 export 'src/result/result.dart';
 export 'src/result/value.dart';
 export 'src/single_subscription_transformer.dart';

--- a/lib/src/result/future_extension.dart
+++ b/lib/src/result/future_extension.dart
@@ -1,0 +1,13 @@
+import 'error.dart';
+import 'result.dart';
+
+/// [CaptureExtension] is an extension to capture any error into
+/// the [Result.capture] property allowing inline catching
+extension CaptureExtension<T> on Future<T> {
+  /// Captures the result of a future into a `Result` future.
+  ///
+  /// The resulting future will never have an error.
+  /// Errors have been converted to an [ErrorResult] value.
+  ///
+  Future<Result<T>> capture() => Result.capture(this);
+}

--- a/test/result/result_future_test.dart
+++ b/test/result/result_future_test.dart
@@ -41,4 +41,25 @@ void main() {
       expect(error.stackTrace, equals(trace));
     });
   });
+  test('capture any future into a result', () async {
+    final future = Future.value(1).capture();
+
+    expect(future, isA<Future<Result<int>>>());
+    final result = await future;
+    expect(result, isA<Result<int>>());
+    expect(result.isError, false);
+    expect(result.asValue?.value, 1);
+  });
+  test('error on capture future are captured properly', () async {
+    final future = <int>() async {
+      throw Exception('custome exception');
+    }()
+        .capture();
+
+    expect(future, isA<Future<Result<int>>>());
+    final result = await future;
+    expect(result, isA<Result<int>>());
+    expect(result.isError, true);
+    expect(result.asError?.error, isA<Exception>());
+  });
 }


### PR DESCRIPTION
- This simple extension will allow to full use the `Result<T>` capabilities simplifying the process of capturing Futures.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
