### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,3 +15,6 @@ dev_dependencies:
   fake_async: ^1.2.0
   stack_trace: ^1.10.0
   test: ^1.16.0
+
+topics:
+- async


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics