### PR TITLE
[Feature] add shorter way to get `value` from `Result`

### DIFF
--- a/lib/async.dart
+++ b/lib/async.dart
@@ -27,6 +27,7 @@ export 'src/restartable_timer.dart';
 export 'src/result/error.dart';
 export 'src/result/future.dart';
 export 'src/result/result.dart';
+export 'src/result/result_extensions.dart';
 export 'src/result/value.dart';
 export 'src/single_subscription_transformer.dart';
 export 'src/sink_base.dart';

--- a/lib/src/result/result_extensions.dart
+++ b/lib/src/result/result_extensions.dart
@@ -1,0 +1,16 @@
+import 'result.dart';
+
+extension ResultExtensions<T> on Result<T> {
+  /// Returns the value if the result [isValue].
+  ///
+  /// If the result [isError], it throws the corresponding error and stacktrace.
+  T get requireValue {
+    if (isValue) return asValue!.value;
+    Error.throwWithStackTrace(asError!.error, asError!.stackTrace);
+  }
+
+  /// Returns the value if the result [isValue].
+  ///
+  /// Returns null otherwise
+  T? get valueOrNull => asValue?.value;
+}

--- a/test/result/result_extensions_test.dart
+++ b/test/result/result_extensions_test.dart
@@ -1,0 +1,67 @@
+import 'package:async/async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('test requiredValue', () {
+    test(
+      'return value when result is value',
+      () {
+        final result = Result.value(10);
+        expect(result.requireValue, 10);
+      },
+    );
+
+    test(
+      'return nullable value when result is nullable value',
+      () {
+        final result = Result<int?>.value(null);
+        expect(result.requireValue, null);
+      },
+    );
+
+    test(
+      'throw exception when result is error',
+      () async {
+        final result = Result.error('error');
+        expect(() => result.requireValue, throwsA(anything));
+      },
+    );
+
+    test(
+      'throw the corresponding and stacktrace exception when result is error',
+      () async {
+        final error = Exception();
+        final stacktrace = StackTrace.current;
+        final result = Result.error(error,stacktrace);
+
+        expect(
+          () => result.requireValue,
+          throwsA(
+            predicate((err) {
+              return err == error;
+            }),
+          ),
+        );
+      },
+    );
+  });
+
+  group('test valueOrNull', () {
+    test('return null when result is error', (){
+      final result = Result.error('error');
+      expect(result.valueOrNull, null);
+    });
+
+    test('return value when result is value ', (){
+      final result = Result.value(10);
+      expect(result.valueOrNull, 10);
+    });
+    
+    test('return nullable value when result is nullable value ', (){
+      final result = Result<int?>.value(null);
+      expect(result.valueOrNull, null);
+    });
+    
+  });
+
+}

--- a/test/result/result_extensions_test.dart
+++ b/test/result/result_extensions_test.dart
@@ -32,7 +32,7 @@ void main() {
       () async {
         final error = Exception();
         final stacktrace = StackTrace.current;
-        final result = Result.error(error,stacktrace);
+        final result = Result.error(error, stacktrace);
 
         expect(
           () => result.requireValue,
@@ -47,21 +47,19 @@ void main() {
   });
 
   group('test valueOrNull', () {
-    test('return null when result is error', (){
+    test('return null when result is error', () {
       final result = Result.error('error');
       expect(result.valueOrNull, null);
     });
 
-    test('return value when result is value ', (){
+    test('return value when result is value ', () {
       final result = Result.value(10);
       expect(result.valueOrNull, 10);
     });
-    
-    test('return nullable value when result is nullable value ', (){
+
+    test('return nullable value when result is nullable value ', () {
       final result = Result<int?>.value(null);
       expect(result.valueOrNull, null);
     });
-    
   });
-
 }


### PR DESCRIPTION
Adding shorter and more readable way to get value from `Result`

old 

```dart
final result = Result.value(10);
if(result.isValue) result.asValue!.value
// or 
result.asValue?.value
```

new
```dart
final result = Result.value(10);
if(result.isValue) result.requiredValue
// or
result.valueOrNull
```
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
