### PR TITLE
feat: add timed_async_memoizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.12.0-wip
 
 - Require Dart 3.4
+- Add `TimedAsyncMemoizer`, a variant of `AsyncMemoizer` that can run the
+  function again when it has expired.
 
 ## 2.11.0
 

--- a/lib/async.dart
+++ b/lib/async.dart
@@ -42,4 +42,5 @@ export 'src/stream_splitter.dart';
 export 'src/stream_subscription_transformer.dart';
 export 'src/stream_zip.dart';
 export 'src/subscription_stream.dart';
+export 'src/timed_async_memoizer.dart';
 export 'src/typed_stream_transformer.dart';

--- a/lib/src/timed_async_memoizer.dart
+++ b/lib/src/timed_async_memoizer.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import '../async.dart';
+
+/// A class that wraps [AsyncMemoizer] it provides the same behavior where
+/// you need a result of a function to be cached but for a short duration.
+class TimedAsyncMemoizer<T> {
+  TimedAsyncMemoizer({
+    this.expiryDuration = const Duration(seconds: 5),
+  });
+
+  final Duration expiryDuration;
+
+  AsyncMemoizer<T>? _memoizer;
+  late DateTime _expiryTime;
+
+  /// Returns true if `DateTime.now()` is after [_expiryTime] or
+  /// if [_memoizer] is null.
+  bool get isExpired {
+    if (_memoizer == null) {
+      return true;
+    }
+
+    return DateTime.now().isAfter(_expiryTime);
+  }
+
+  /// Runs the function [computation], if it hasn't been run before
+  /// and if the cache has expired.
+  ///
+  /// If it has already been run and cache has not expired it will return the
+  /// cached result.
+  Future<T> run(FutureOr<T> Function() computation) {
+    if (isExpired) {
+      _init();
+    }
+
+    assert(_memoizer != null);
+
+    return _memoizer!.runOnce(computation);
+  }
+
+  void _init() {
+    _memoizer = AsyncMemoizer();
+    _expiryTime = DateTime.now().add(expiryDuration);
+  }
+}

--- a/test/timed_async_memoizer_test.dart
+++ b/test/timed_async_memoizer_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TimedAsyncMemoizer Tests', () {
+    final delay = const Duration(milliseconds: 10);
+    late TimedAsyncMemoizer memoizer;
+
+    setUp(() {
+      memoizer = TimedAsyncMemoizer(
+        expiryDuration: delay,
+      );
+    });
+
+    test('isExpired returns true when run() is not called', () {
+      expect(memoizer.isExpired, true);
+    });
+
+    test(
+      'isExpired returns false when run() is called and not expired',
+      () async {
+        await memoizer.run(() => Future.value(1));
+        expect(memoizer.isExpired, false);
+      },
+    );
+
+    test(
+      'isExpired returns true when run() is called and expired',
+      () async {
+        await memoizer.run(() => Future.value(1));
+        await Future.delayed(delay);
+        expect(memoizer.isExpired, true);
+      },
+    );
+
+    test('runs function once when not expired', () async {
+      var count = 0;
+      void c() {
+        count++;
+      }
+
+      await memoizer.run(c);
+      await memoizer.run(c);
+      await memoizer.run(c);
+      await memoizer.run(c);
+      await memoizer.run(c);
+
+      expect(count, 1);
+    });
+
+    test('runs function multiple times when expired', () async {
+      var count = 0;
+      void c() {
+        count++;
+      }
+
+      await memoizer.run(c);
+      await Future.delayed(delay);
+      await memoizer.run(c);
+
+      expect(count, 2);
+    });
+
+    test('returns the result of the function', () async {
+      expect(memoizer.run(() => 'value'), completion(equals('value')));
+      expect(memoizer.run(() {}), completion(equals('value')));
+    });
+
+    test('returns new result when expired', () async {
+      expect(memoizer.run(() => 'value'), completion(equals('value')));
+      await Future.delayed(delay);
+      expect(memoizer.run(() => 'value2'), completion(equals('value2')));
+    });
+
+    test('returns thrown error of the function', () async {
+      expect(memoizer.run(() async => throw 'error'), throwsA('error'));
+      expect(memoizer.run(() {}), throwsA('error'));
+    });
+
+    test('returns new thrown error when expired', () async {
+      expect(memoizer.run(() async => throw 'error'), throwsA('error'));
+      await Future.delayed(delay);
+      expect(memoizer.run(() async => throw 'error2'), throwsA('error2'));
+    });
+  });
+}


### PR DESCRIPTION
- Implement an AsyncMemoizer that has an expiring duration.

- This adds a variant of the AsyncMemoizer where the cached result can expire. I find this useful for caching a particular result that I need for a very short duration.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
